### PR TITLE
init(start:end:) due to be deprecated in Swift 3

### DIFF
--- a/verdeciel/String.swift
+++ b/verdeciel/String.swift
@@ -11,7 +11,7 @@ extension String
 		var start = start
 		if start+length > self.characters.count { length = self.characters.count - start }
 		if start > self.characters.count { start = self.characters.count ; length = 0 }
-		let range = Range<String.Index>(start: startIndex.advancedBy(start), end: startIndex.advancedBy(start + length))
+		let range = self.startIndex.advancedBy(start) ..< self.startIndex.advancedBy(start + length)
 		return self.substringWithRange(range)
 	}
 }


### PR DESCRIPTION
See: http://://stackoverflow.com/a/36158697/28290 for more info on this syntax