### PR TITLE
Minor panel fixes

### DIFF
--- a/verreciel_js/scripts/collections/missions.js
+++ b/verreciel_js/scripts/collections/missions.js
@@ -872,7 +872,6 @@ class Missions
       }
       location.isKnown = true;
     }
-    verreciel.intercom.locationPanel.empty();
   }
   
   refresh()

--- a/verreciel_js/scripts/core/game.js
+++ b/verreciel_js/scripts/core/game.js
@@ -30,6 +30,7 @@ class Game
     }
     localStorage.state = id;
     localStorage.version = verreciel.version;
+    verreciel.completion.refresh();
   }
   
   load(id)

--- a/verreciel_js/scripts/locations/location.js
+++ b/verreciel_js/scripts/locations/location.js
@@ -234,7 +234,10 @@ class Location extends Event
     verreciel.progress.refresh();
     this.icon.onUpdate();
     this.structure.onComplete();
-    verreciel.intercom.complete();
+    if (verreciel.intercom.port.event == this)
+    {
+      verreciel.intercom.complete();
+    }
     verreciel.music.playEffect("beep1");
   }
   

--- a/verreciel_js/scripts/panels/mainpanels/console.js
+++ b/verreciel_js/scripts/panels/mainpanels/console.js
@@ -173,7 +173,7 @@ class ConsoleLine extends Empty
     this.port.hide();
     this.add(this.port);
     
-    this.textLabel = new SceneLabel("", 0.1, Alignment.left);
+    this.textLabel = new SceneLabel("", 0.0875, Alignment.left);
     this.textLabel.position.set(0.3, 0, 0);
     this.add(this.textLabel);
     

--- a/verreciel_js/scripts/panels/mainpanels/intercom.js
+++ b/verreciel_js/scripts/panels/mainpanels/intercom.js
@@ -160,8 +160,11 @@ class Intercom extends MainPanel
       return;
     }
     this.isCompleting = true;
+
+    verreciel.animator.completeAnimation("intercom_connect_1");
+    verreciel.animator.completeAnimation("intercom_connect_2");
     
-    verreciel.animator.begin();
+    verreciel.animator.begin("intercom_complete_1");
     verreciel.animator.animationDuration = 0.5;
     
     this.locationPanel.position.set(0,0,-0.5);
@@ -171,7 +174,7 @@ class Intercom extends MainPanel
 
       // this.defaultPanel.position.set(0,0,-0.5);
       
-      verreciel.animator.begin();
+      verreciel.animator.begin("intercom_complete_2");
       verreciel.animator.animationDuration = 0.5;
       
       this.defaultPanel.position.set(0,0,0);
@@ -202,7 +205,12 @@ class Intercom extends MainPanel
     
     // Animate
     
-    verreciel.animator.begin();
+    verreciel.animator.completeAnimation("intercom_complete_1");
+    verreciel.animator.completeAnimation("intercom_complete_2");
+    verreciel.animator.completeAnimation("intercom_disconnect_1");
+    verreciel.animator.completeAnimation("intercom_disconnect_2");
+
+    verreciel.animator.begin("intercom_connect_1");
     verreciel.animator.animationDuration = 0.5;
     
     this.defaultPanel.position.set(0,0,-0.5);
@@ -217,7 +225,7 @@ class Intercom extends MainPanel
         this.nameLabel.updateText(null); // TODO: Surely this is meant to contain something?
       }
       
-      verreciel.animator.begin();
+      verreciel.animator.begin("intercom_connect_2");
       verreciel.animator.animationDuration = 0.5;
       
       this.locationPanel.position.set(0,0,0);
@@ -246,7 +254,10 @@ class Intercom extends MainPanel
 
     ScenePort.stripAllPorts(this);
 
-    verreciel.animator.begin();
+    verreciel.animator.completeAnimation("intercom_connect_1");
+    verreciel.animator.completeAnimation("intercom_connect_2");
+
+    verreciel.animator.begin("intercom_disconnect_1");
     verreciel.animator.animationDuration = 0.5;
     
     this.locationPanel.position.set(0,0,-0.5);
@@ -256,7 +267,7 @@ class Intercom extends MainPanel
       
       this.defaultPanel.position.set(0,0,-0.5);
       
-      verreciel.animator.begin();
+      verreciel.animator.begin("intercom_disconnect_2");
       verreciel.animator.animationDuration = 0.5;
       
       this.defaultPanel.position.set(0,0,0);


### PR DESCRIPTION
The monitor labeled "MISSIONS" now refreshes when the game saves.
There is now room in the Console for "HORIZONTAL PART" to sit next to "FRAGMENT". 

Sorry for the all caps!

I also discovered and resolved an issue where the Intercom panel would sometimes show the wrong info on startup, due to overlapping animations.