### PR TITLE
I was walking with a ghost

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 .DS_Store
 *.xcodeproj
+*.sublime-workspace
+*.sublime-project

--- a/verreciel_js/TODO.txt
+++ b/verreciel_js/TODO.txt
@@ -1,6 +1,9 @@
+Ghost gets stuck on pilot
+  Pilot should give OK immediately if necessary
+Ghost gets stuck on thruster in one spot
+
 TODO: change horadric reports from currency names to currency codes
   Update the walkthrough
-Ghost gets stuck on unready IKOV harvest
 Doesn't indicate readiness, doesn't auto-upload. What to do?
 
 Make ghost hang out closer to where he last was instead of center, with room to dance
@@ -8,18 +11,10 @@ Add pause between ghost appear and first ghost replay step
 Animate ghost button tap
 Revisit ghost face angle
 
-console - valen key 2 bug
-
+----
 
 It's weird when the helmet gives old quest instructions for the current mission
   I don't mean in response to mistakes, I mean when the player's doing the right thing
-
-Walkthroughs
-
-  Mission walkthrough chapters
-  Record walkthrough chapters
-  Test for each recipe
-  Chapter to reach other areas
 
 -------
 

--- a/verreciel_js/TODO.txt
+++ b/verreciel_js/TODO.txt
@@ -1,6 +1,3 @@
-Listening to record while returning from valen to loiqe should continue playing record, not switch to loiqe ambient
-Extinguishing a sun should disconnect the end key, but it doesn't
-
 Walkthroughs
 
   Mission walkthrough chapters

--- a/verreciel_js/TODO.txt
+++ b/verreciel_js/TODO.txt
@@ -1,3 +1,9 @@
+Removing shield next to extinguished sun causes stuck autopilot
+Removing shield next to non-extinguished sun?
+
+It's weird when the helmet gives old quest instructions for the current mission
+  I don't mean in response to mistakes, I mean when the player's doing the right thing
+
 Walkthroughs
 
   Mission walkthrough chapters

--- a/verreciel_js/TODO.txt
+++ b/verreciel_js/TODO.txt
@@ -1,3 +1,5 @@
+Horadric out doesn't like piping straight to Radio
+
 Walkthroughs
 
   Mission walkthrough chapters

--- a/verreciel_js/TODO.txt
+++ b/verreciel_js/TODO.txt
@@ -1,6 +1,3 @@
-Removing shield next to extinguished sun causes stuck autopilot
-Removing shield next to non-extinguished sun?
-
 It's weird when the helmet gives old quest instructions for the current mission
   I don't mean in response to mistakes, I mean when the player's doing the right thing
 

--- a/verreciel_js/TODO.txt
+++ b/verreciel_js/TODO.txt
@@ -1,5 +1,3 @@
-Horadric out doesn't like piping straight to Radio
-
 Walkthroughs
 
   Mission walkthrough chapters

--- a/verreciel_js/TODO.txt
+++ b/verreciel_js/TODO.txt
@@ -1,6 +1,3 @@
-Make ghost hang out closer to where he last was instead of center, with room to dance
-Add pause between ghost appear and first ghost replay step
-Animate ghost button tap
 Revisit ghost face angle
 
 ----

--- a/verreciel_js/TODO.txt
+++ b/verreciel_js/TODO.txt
@@ -1,11 +1,3 @@
-Ghost gets stuck on pilot
-  Pilot should give OK immediately if necessary
-Ghost gets stuck on thruster in one spot
-
-TODO: change horadric reports from currency names to currency codes
-  Update the walkthrough
-Doesn't indicate readiness, doesn't auto-upload. What to do?
-
 Make ghost hang out closer to where he last was instead of center, with room to dance
 Add pause between ghost appear and first ghost replay step
 Animate ghost button tap

--- a/verreciel_js/TODO.txt
+++ b/verreciel_js/TODO.txt
@@ -1,3 +1,6 @@
+Listening to record while returning from valen to loiqe should continue playing record, not switch to loiqe ambient
+Extinguishing a sun should disconnect the end key, but it doesn't
+
 Walkthroughs
 
   Mission walkthrough chapters

--- a/verreciel_js/TODO.txt
+++ b/verreciel_js/TODO.txt
@@ -1,7 +1,3 @@
-Revisit ghost face angle
-
-----
-
 It's weird when the helmet gives old quest instructions for the current mission
   I don't mean in response to mistakes, I mean when the player's doing the right thing
 

--- a/verreciel_js/TODO.txt
+++ b/verreciel_js/TODO.txt
@@ -1,13 +1,9 @@
 Walkthroughs
-  Player rotate, click, predicate
-  Game speed modification
 
   Mission walkthrough chapters
   Record walkthrough chapters
   Test for each recipe
   Chapter to reach other areas
-
-Use the walkthrough to detect any other late THREE.js class construction
 
 -------
 

--- a/verreciel_js/TODO.txt
+++ b/verreciel_js/TODO.txt
@@ -1,3 +1,16 @@
+TODO: change horadric reports from currency names to currency codes
+  Update the walkthrough
+Ghost gets stuck on unready IKOV harvest
+Doesn't indicate readiness, doesn't auto-upload. What to do?
+
+Make ghost hang out closer to where he last was instead of center, with room to dance
+Add pause between ghost appear and first ghost replay step
+Animate ghost button tap
+Revisit ghost face angle
+
+console - valen key 2 bug
+
+
 It's weird when the helmet gives old quest instructions for the current mission
   I don't mean in response to mistakes, I mean when the player's doing the right thing
 

--- a/verreciel_js/index.html
+++ b/verreciel_js/index.html
@@ -39,6 +39,7 @@
     <script type="text/javascript" src="scripts/core/verreciel.js"></script>
     <script type="text/javascript" src="scripts/core/music.js"></script>
 
+    <script type="text/javascript" src="scripts/core/ghost.js"></script>
     <script type="text/javascript" src="scripts/core/universe.js"></script>
     <script type="text/javascript" src="scripts/core/game.js"></script>
     <script type="text/javascript" src="scripts/core/player.js"></script>

--- a/verreciel_js/index.html
+++ b/verreciel_js/index.html
@@ -123,6 +123,7 @@
 
         let DEBUG_SKIP_LOGO = false;
         let DEBUG_SHOW_TRIGGERS = false;
+        let DEBUG_LOG_TRIGGERS = false;
         let DEBUG_DONT_SAVE = false;
         let DEBUG_NO_MUSIC = false;
         let DEBUG_SHOW_STATS = false;

--- a/verreciel_js/index.html
+++ b/verreciel_js/index.html
@@ -123,7 +123,7 @@
 
         let DEBUG_SKIP_LOGO = false;
         let DEBUG_SHOW_TRIGGERS = false;
-        let DEBUG_LOG_TRIGGERS = false;
+        let DEBUG_LOG_GHOST = false;
         let DEBUG_DONT_SAVE = false;
         let DEBUG_NO_MUSIC = false;
         let DEBUG_SHOW_STATS = false;

--- a/verreciel_js/media/walkthrough.json
+++ b/verreciel_js/media/walkthrough.json
@@ -1,0 +1,2914 @@
+[
+  { "type": "mission", "data": 0 },
+  { "type": "playerUnlock", "data": 0 },
+  {
+    "type": "hit",
+    "data": {
+      "from": "port",
+      "numberlessName": "battery_slot_cell#",
+      "event": "battery-1"
+    }
+  },
+  {
+    "type": "hit",
+    "data": { "from": "port", "name": "battery_slot_thruster" }
+  },
+  { "type": "playerUnlock", "data": -45 },
+  { "type": "hit", "data": { "from": "trigger", "name": "thruster_action" } },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  { "type": "playerUnlock", "data": -225 },
+  { "type": "hit", "data": { "from": "port", "name": "loiqe-Harvest_alta" } },
+  { "type": "hit", "data": { "from": "port", "name": "mainpanel_cargo" } },
+  { "type": "playerUnlock", "data": -270 },
+  { "type": "hit", "data": { "from": "port", "name": "mainpanel_cargo" } },
+  { "type": "hit", "data": { "from": "port", "name": "mainpanel_console" } },
+  { "type": "hit", "data": { "from": "trigger", "name": "thruster_action" } },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  { "type": "mission", "data": 0 },
+  { "type": "docked", "data": "City" },
+  {
+    "type": "hit",
+    "data": {
+      "from": "port",
+      "numberlessName": "console_line_#",
+      "event": null
+    }
+  },
+  { "type": "hit", "data": { "from": "port", "name": "loiqe-City_want" } },
+  { "type": "upload", "data": "loiqe-City_want" },
+  { "type": "hit", "data": { "from": "port", "name": "loiqe-City_give" } },
+  { "type": "hit", "data": { "from": "port", "name": "mainpanel_cargo" } },
+  { "type": "mission", "data": 1 },
+  { "type": "install", "data": "map" },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "location_loiqe-satellite" }
+  },
+  { "type": "playerUnlock", "data": -135 },
+  { "type": "hit", "data": { "from": "port", "name": "mainpanel_radar" } },
+  { "type": "hit", "data": { "from": "port", "name": "mainpanel_pilot" } },
+  { "type": "mission", "data": 2 },
+  { "type": "pilotAligned", "data": "satellite" },
+  { "type": "hit", "data": { "from": "trigger", "name": "thruster_action" } },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  { "type": "docked", "data": "satellite" },
+  {
+    "type": "hit",
+    "data": { "from": "port", "name": "loiqe-satellite_valen part 2" }
+  },
+  { "type": "hit", "data": { "from": "port", "name": "mainpanel_cargo" } },
+  { "type": "upload", "data": "cargo" },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "location_loiqe-Horadric" }
+  },
+  { "type": "pilotAligned", "data": "Horadric" },
+  { "type": "hit", "data": { "from": "trigger", "name": "thruster_action" } },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  { "type": "docked", "data": "Horadric" },
+  {
+    "type": "hit",
+    "data": {
+      "from": "port",
+      "numberlessName": "console_line_#",
+      "event": "valen-key-1"
+    }
+  },
+  {
+    "type": "hit",
+    "data": {
+      "from": "port",
+      "numberlessName": "loiqe-Horadric_input_#",
+      "event": null
+    }
+  },
+  { "type": "upload", "data": "loiqe-Horadric_input_2" },
+  {
+    "type": "hit",
+    "data": {
+      "from": "port",
+      "numberlessName": "console_line_#",
+      "event": "valen-key-2"
+    }
+  },
+  {
+    "type": "hit",
+    "data": {
+      "from": "port",
+      "numberlessName": "loiqe-Horadric_input_#",
+      "event": null
+    }
+  },
+  { "type": "combination", "data": "valen key" },
+  {
+    "type": "hit",
+    "data": { "from": "port", "name": "loiqe-Horadric_output_1" }
+  },
+  { "type": "hit", "data": { "from": "port", "name": "mainpanel_cargo" } },
+  { "type": "mission", "data": 3 },
+  { "type": "install", "data": "exploration" },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "location_loiqe-satellite" }
+  },
+  { "type": "pilotAligned", "data": "satellite" },
+  { "type": "hit", "data": { "from": "trigger", "name": "thruster_action" } },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  { "type": "docked", "data": "satellite" },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "location_loiqe-portal" }
+  },
+  { "type": "pilotAligned", "data": "portal" },
+  { "type": "hit", "data": { "from": "trigger", "name": "thruster_action" } },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  { "type": "docked", "data": "portal" },
+  {
+    "type": "hit",
+    "data": {
+      "from": "port",
+      "numberlessName": "console_line_#",
+      "event": "valen-key"
+    }
+  },
+  { "type": "hit", "data": { "from": "port", "name": "mainpanel_mission" } },
+  {
+    "type": "hit",
+    "data": { "from": "port", "name": "loiqe-portal_thruster" }
+  },
+  { "type": "hit", "data": { "from": "port", "name": "mainpanel_thruster" } },
+  { "type": "hit", "data": { "from": "port", "name": "mainpanel_radar" } },
+  { "type": "hit", "data": { "from": "port", "name": "mainpanel_radar" } },
+  { "type": "hit", "data": { "from": "port", "name": "loiqe-portal_pilot" } },
+  { "type": "hit", "data": { "from": "port", "name": "mainpanel_pilot" } },
+  { "type": "pilotAligned", "data": "portal" },
+  { "type": "hit", "data": { "from": "trigger", "name": "thruster_action" } },
+  { "type": "docked", "data": "portal" },
+  { "type": "hit", "data": { "from": "port", "name": "mainpanel_radar" } },
+  { "type": "hit", "data": { "from": "port", "name": "mainpanel_pilot" } },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "location_valen-Bank" }
+  },
+  { "type": "hit", "data": { "from": "trigger", "name": "thruster_action" } },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  { "type": "docked", "data": "Bank" },
+  {
+    "type": "hit",
+    "data": {
+      "from": "port",
+      "numberlessName": "valen-Bank_slot_#",
+      "event": "record1"
+    }
+  },
+  { "type": "hit", "data": { "from": "port", "name": "mainpanel_cargo" } },
+  { "type": "upload", "data": "cargo" },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "location_valen-cargo" }
+  },
+  { "type": "hit", "data": { "from": "trigger", "name": "thruster_action" } },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  { "type": "docked", "data": "cargo" },
+  { "type": "hit", "data": { "from": "port", "name": "valen-cargo_cell" } },
+  { "type": "hit", "data": { "from": "port", "name": "mainpanel_cargo" } },
+  { "type": "upload", "data": "cargo" },
+  {
+    "type": "hit",
+    "data": {
+      "from": "port",
+      "numberlessName": "console_line_#",
+      "event": "battery-2"
+    }
+  },
+  {
+    "type": "hit",
+    "data": {
+      "from": "port",
+      "numberlessName": "battery_slot_cell#",
+      "event": null
+    }
+  },
+  { "type": "upload", "data": "battery_slot_cell2" },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "location_valen-harvest" }
+  },
+  { "type": "pilotAligned", "data": "harvest" },
+  { "type": "hit", "data": { "from": "trigger", "name": "thruster_action" } },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  { "type": "docked", "data": "harvest" },
+  { "type": "hit", "data": { "from": "port", "name": "valen-harvest_ikov" } },
+  { "type": "hit", "data": { "from": "port", "name": "mainpanel_cargo" } },
+  { "type": "upload", "data": "cargo" },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "location_valen-station" }
+  },
+  { "type": "pilotAligned", "data": "station" },
+  { "type": "hit", "data": { "from": "trigger", "name": "thruster_action" } },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  { "type": "docked", "data": "station" },
+  {
+    "type": "hit",
+    "data": {
+      "from": "port",
+      "numberlessName": "console_line_#",
+      "event": null
+    }
+  },
+  { "type": "hit", "data": { "from": "port", "name": "valen-station" } },
+  { "type": "upload", "data": "valen-station" },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "button_valen-station_install" }
+  },
+  { "type": "install", "data": "journey" },
+  {
+    "type": "hit",
+    "data": {
+      "from": "port",
+      "numberlessName": "battery_slot_cell#",
+      "event": "battery-2"
+    }
+  },
+  { "type": "hit", "data": { "from": "port", "name": "battery_slot_radio" } },
+  {
+    "type": "hit",
+    "data": {
+      "from": "port",
+      "numberlessName": "console_line_#",
+      "event": "record1"
+    }
+  },
+  { "type": "hit", "data": { "from": "port", "name": "widget_radio" } },
+  { "type": "mission", "data": 6 },
+  { "type": "upload", "data": "widget_radio" },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "location_valen-Bank" }
+  },
+  { "type": "pilotAligned", "data": "Bank" },
+  { "type": "hit", "data": { "from": "trigger", "name": "thruster_action" } },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  { "type": "docked", "data": "Bank" },
+  {
+    "type": "hit",
+    "data": {
+      "from": "port",
+      "numberlessName": "valen-Bank_slot_#",
+      "event": null
+    }
+  },
+  { "type": "hit", "data": { "from": "port", "name": "mainpanel_cargo" } },
+  { "type": "playerUnlock", "data": -315 },
+  {
+    "type": "hit",
+    "data": {
+      "from": "port",
+      "numberlessName": "console_line_#",
+      "event": null
+    }
+  },
+  { "type": "hit", "data": { "from": "port", "name": "mainpanel_hatch" } },
+  { "type": "hit", "data": { "from": "trigger", "name": "hatch_jettison" } },
+  { "type": "install", "data": "missions" },
+  {
+    "type": "hit",
+    "data": {
+      "from": "port",
+      "numberlessName": "valen-Bank_slot_#",
+      "event": "loiqe-key"
+    }
+  },
+  { "type": "hit", "data": { "from": "port", "name": "mainpanel_cargo" } },
+  { "type": "mission", "data": 8 },
+  { "type": "upload", "data": "cargo" },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "location_valen-harvest" }
+  },
+  { "type": "pilotAligned", "data": "harvest" },
+  { "type": "hit", "data": { "from": "trigger", "name": "thruster_action" } },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  { "type": "docked", "data": "harvest" },
+  { "type": "hit", "data": { "from": "port", "name": "valen-harvest_ikov" } },
+  { "type": "hit", "data": { "from": "port", "name": "mainpanel_cargo" } },
+  { "type": "upload", "data": "cargo" },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "location_valen-Bank" }
+  },
+  { "type": "pilotAligned", "data": "Bank" },
+  { "type": "hit", "data": { "from": "trigger", "name": "thruster_action" } },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  { "type": "docked", "data": "Bank" },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "location_valen-portal" }
+  },
+  { "type": "pilotAligned", "data": "portal" },
+  { "type": "hit", "data": { "from": "trigger", "name": "thruster_action" } },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  { "type": "docked", "data": "portal" },
+  {
+    "type": "hit",
+    "data": {
+      "from": "port",
+      "numberlessName": "console_line_#",
+      "event": "loiqe-key"
+    }
+  },
+  { "type": "hit", "data": { "from": "port", "name": "mainpanel_mission" } },
+  {
+    "type": "hit",
+    "data": { "from": "port", "name": "valen-portal_thruster" }
+  },
+  { "type": "hit", "data": { "from": "port", "name": "mainpanel_thruster" } },
+  { "type": "hit", "data": { "from": "port", "name": "mainpanel_radar" } },
+  { "type": "hit", "data": { "from": "port", "name": "mainpanel_radar" } },
+  { "type": "hit", "data": { "from": "port", "name": "valen-portal_pilot" } },
+  { "type": "hit", "data": { "from": "port", "name": "mainpanel_pilot" } },
+  { "type": "hit", "data": { "from": "trigger", "name": "thruster_action" } },
+  { "type": "docked", "data": "portal" },
+  { "type": "hit", "data": { "from": "port", "name": "mainpanel_radar" } },
+  { "type": "hit", "data": { "from": "port", "name": "mainpanel_pilot" } },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "location_loiqe-satellite" }
+  },
+  { "type": "pilotAligned", "data": "satellite" },
+  { "type": "hit", "data": { "from": "trigger", "name": "thruster_action" } },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  { "type": "docked", "data": "satellite" },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "location_loiqe-City" }
+  },
+  { "type": "pilotAligned", "data": "City" },
+  { "type": "hit", "data": { "from": "trigger", "name": "thruster_action" } },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  { "type": "docked", "data": "City" },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "location_loiqe-Harvest" }
+  },
+  { "type": "pilotAligned", "data": "Harvest" },
+  { "type": "hit", "data": { "from": "trigger", "name": "thruster_action" } },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  { "type": "docked", "data": "Harvest" },
+  { "type": "hit", "data": { "from": "port", "name": "loiqe-Harvest_alta" } },
+  { "type": "hit", "data": { "from": "port", "name": "mainpanel_cargo" } },
+  { "type": "upload", "data": "cargo" },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "location_loiqe-City" }
+  },
+  { "type": "pilotAligned", "data": "City" },
+  { "type": "hit", "data": { "from": "trigger", "name": "thruster_action" } },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  { "type": "docked", "data": "City" },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "location_loiqe-satellite" }
+  },
+  { "type": "pilotAligned", "data": "satellite" },
+  { "type": "hit", "data": { "from": "trigger", "name": "thruster_action" } },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  { "type": "docked", "data": "satellite" },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "location_loiqe-Horadric" }
+  },
+  { "type": "pilotAligned", "data": "Horadric" },
+  { "type": "hit", "data": { "from": "trigger", "name": "thruster_action" } },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  { "type": "docked", "data": "Horadric" },
+  {
+    "type": "hit",
+    "data": {
+      "from": "port",
+      "numberlessName": "console_line_#",
+      "event": null
+    }
+  },
+  {
+    "type": "hit",
+    "data": {
+      "from": "port",
+      "numberlessName": "loiqe-Horadric_input_#",
+      "event": null
+    }
+  },
+  { "type": "upload", "data": "loiqe-Horadric_input_2" },
+  {
+    "type": "hit",
+    "data": {
+      "from": "port",
+      "numberlessName": "console_line_#",
+      "event": null
+    }
+  },
+  {
+    "type": "hit",
+    "data": {
+      "from": "port",
+      "numberlessName": "loiqe-Horadric_input_#",
+      "event": null
+    }
+  },
+  { "type": "combination", "data": "altiov" },
+  {
+    "type": "hit",
+    "data": { "from": "port", "name": "loiqe-Horadric_output_1" }
+  },
+  { "type": "hit", "data": { "from": "port", "name": "mainpanel_cargo" } },
+  { "type": "upload", "data": "cargo" },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "location_loiqe-satellite" }
+  },
+  { "type": "pilotAligned", "data": "satellite" },
+  { "type": "hit", "data": { "from": "trigger", "name": "thruster_action" } },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  { "type": "docked", "data": "satellite" },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "location_loiqe-portal" }
+  },
+  { "type": "pilotAligned", "data": "portal" },
+  { "type": "hit", "data": { "from": "trigger", "name": "thruster_action" } },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  { "type": "docked", "data": "portal" },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "location_loiqe-port" }
+  },
+  { "type": "pilotAligned", "data": "port" },
+  { "type": "hit", "data": { "from": "trigger", "name": "thruster_action" } },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  { "type": "docked", "data": "port" },
+  {
+    "type": "hit",
+    "data": {
+      "from": "port",
+      "numberlessName": "console_line_#",
+      "event": null
+    }
+  },
+  { "type": "hit", "data": { "from": "port", "name": "loiqe-port_want" } },
+  { "type": "upload", "data": "loiqe-port_want" },
+  { "type": "hit", "data": { "from": "port", "name": "loiqe-port_give" } },
+  { "type": "hit", "data": { "from": "port", "name": "mainpanel_cargo" } },
+  { "type": "upload", "data": "cargo" },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "location_loiqe-portal" }
+  },
+  { "type": "pilotAligned", "data": "portal" },
+  { "type": "hit", "data": { "from": "trigger", "name": "thruster_action" } },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  { "type": "docked", "data": "portal" },
+  {
+    "type": "hit",
+    "data": {
+      "from": "port",
+      "numberlessName": "console_line_#",
+      "event": "senni-key"
+    }
+  },
+  { "type": "hit", "data": { "from": "port", "name": "mainpanel_mission" } },
+  {
+    "type": "hit",
+    "data": { "from": "port", "name": "loiqe-portal_thruster" }
+  },
+  { "type": "hit", "data": { "from": "port", "name": "mainpanel_thruster" } },
+  { "type": "hit", "data": { "from": "port", "name": "mainpanel_radar" } },
+  { "type": "hit", "data": { "from": "port", "name": "mainpanel_radar" } },
+  { "type": "hit", "data": { "from": "port", "name": "loiqe-portal_pilot" } },
+  { "type": "hit", "data": { "from": "port", "name": "mainpanel_pilot" } },
+  { "type": "pilotAligned", "data": "portal" },
+  { "type": "hit", "data": { "from": "trigger", "name": "thruster_action" } },
+  { "type": "docked", "data": "portal" },
+  { "type": "hit", "data": { "from": "port", "name": "mainpanel_radar" } },
+  { "type": "hit", "data": { "from": "port", "name": "mainpanel_pilot" } },
+  { "type": "hit", "data": { "from": "trigger", "name": "thruster_action" } },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "location_senni-cargo" }
+  },
+  { "type": "pilotAligned", "data": "cargo" },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  { "type": "docked", "data": "cargo" },
+  { "type": "hit", "data": { "from": "port", "name": "senni-cargo_Fog Map" } },
+  { "type": "hit", "data": { "from": "port", "name": "mainpanel_cargo" } },
+  { "type": "upload", "data": "cargo" },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "location_senni-harvest" }
+  },
+  { "type": "pilotAligned", "data": "harvest" },
+  { "type": "hit", "data": { "from": "trigger", "name": "thruster_action" } },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  { "type": "docked", "data": "harvest" },
+  { "type": "hit", "data": { "from": "port", "name": "senni-harvest_eral" } },
+  { "type": "hit", "data": { "from": "port", "name": "mainpanel_cargo" } },
+  { "type": "upload", "data": "cargo" },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "location_senni-station" }
+  },
+  { "type": "pilotAligned", "data": "station" },
+  { "type": "hit", "data": { "from": "trigger", "name": "thruster_action" } },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  { "type": "docked", "data": "station" },
+  {
+    "type": "hit",
+    "data": {
+      "from": "port",
+      "numberlessName": "console_line_#",
+      "event": null
+    }
+  },
+  { "type": "hit", "data": { "from": "port", "name": "senni-station" } },
+  { "type": "upload", "data": "senni-station" },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "button_senni-station_install" }
+  },
+  { "type": "playerUnlock", "data": -90 },
+  {
+    "type": "hit",
+    "data": {
+      "from": "port",
+      "numberlessName": "battery_slot_cell#",
+      "event": "battery-2"
+    }
+  },
+  { "type": "hit", "data": { "from": "port", "name": "battery_slot_cloak" } },
+  {
+    "type": "hit",
+    "data": {
+      "from": "port",
+      "numberlessName": "console_line_#",
+      "event": "map-1"
+    }
+  },
+  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
+  { "type": "upload", "data": "widget_map" },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "location_senni-fog" }
+  },
+  { "type": "hit", "data": { "from": "trigger", "name": "thruster_action" } },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  { "type": "docked", "data": "fog" },
+  { "type": "hit", "data": { "from": "port", "name": "senni-fog_cell" } },
+  { "type": "hit", "data": { "from": "port", "name": "mainpanel_cargo" } },
+  { "type": "upload", "data": "cargo" },
+  {
+    "type": "hit",
+    "data": {
+      "from": "port",
+      "numberlessName": "console_line_#",
+      "event": "battery-3"
+    }
+  },
+  {
+    "type": "hit",
+    "data": {
+      "from": "port",
+      "numberlessName": "battery_slot_cell#",
+      "event": null
+    }
+  },
+  { "type": "mission", "data": 12 },
+  { "type": "upload", "data": "battery_slot_cell3" },
+  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
+  { "type": "hit", "data": { "from": "port", "name": "player" } },
+  { "type": "mission", "data": 13 },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "location_valen-harvest" }
+  },
+  { "type": "pilotAligned", "data": "harvest" },
+  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
+  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
+  { "type": "hit", "data": { "from": "trigger", "name": "thruster_action" } },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  { "type": "docked", "data": "harvest" },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "location_valen-station" }
+  },
+  { "type": "hit", "data": { "from": "trigger", "name": "thruster_action" } },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  { "type": "docked", "data": "station" },
+  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
+  { "type": "hit", "data": { "from": "port", "name": "player" } },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "location_valen-fog" }
+  },
+  { "type": "pilotAligned", "data": "fog" },
+  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
+  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
+  { "type": "hit", "data": { "from": "trigger", "name": "thruster_action" } },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  { "type": "docked", "data": "fog" },
+  {
+    "type": "hit",
+    "data": { "from": "port", "name": "valen-fog_usul Part 1" }
+  },
+  { "type": "hit", "data": { "from": "port", "name": "mainpanel_cargo" } },
+  { "type": "upload", "data": "cargo" },
+  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
+  { "type": "hit", "data": { "from": "port", "name": "player" } },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "location_loiqe-Horadric" }
+  },
+  { "type": "pilotAligned", "data": "Horadric" },
+  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
+  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
+  { "type": "hit", "data": { "from": "trigger", "name": "thruster_action" } },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  { "type": "docked", "data": "Horadric" },
+  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
+  { "type": "hit", "data": { "from": "port", "name": "player" } },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "location_loiqe-portal" }
+  },
+  { "type": "pilotAligned", "data": "portal" },
+  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
+  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
+  { "type": "hit", "data": { "from": "trigger", "name": "thruster_action" } },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  { "type": "docked", "data": "portal" },
+  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
+  { "type": "hit", "data": { "from": "port", "name": "player" } },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "location_loiqe-fog" }
+  },
+  { "type": "pilotAligned", "data": "fog" },
+  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
+  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
+  { "type": "hit", "data": { "from": "trigger", "name": "thruster_action" } },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  { "type": "docked", "data": "fog" },
+  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
+  { "type": "hit", "data": { "from": "port", "name": "player" } },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "location_loiqe-portal" }
+  },
+  { "type": "pilotAligned", "data": "portal" },
+  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
+  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
+  { "type": "hit", "data": { "from": "trigger", "name": "thruster_action" } },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  { "type": "docked", "data": "portal" },
+  {
+    "type": "hit",
+    "data": {
+      "from": "port",
+      "numberlessName": "console_line_#",
+      "event": "senni-key"
+    }
+  },
+  { "type": "hit", "data": { "from": "port", "name": "mainpanel_mission" } },
+  {
+    "type": "hit",
+    "data": { "from": "port", "name": "loiqe-portal_thruster" }
+  },
+  { "type": "hit", "data": { "from": "port", "name": "mainpanel_thruster" } },
+  { "type": "hit", "data": { "from": "port", "name": "mainpanel_radar" } },
+  { "type": "hit", "data": { "from": "port", "name": "mainpanel_radar" } },
+  { "type": "hit", "data": { "from": "port", "name": "loiqe-portal_pilot" } },
+  { "type": "hit", "data": { "from": "port", "name": "mainpanel_pilot" } },
+  { "type": "pilotAligned", "data": "portal" },
+  { "type": "hit", "data": { "from": "trigger", "name": "thruster_action" } },
+  { "type": "docked", "data": "portal" },
+  { "type": "hit", "data": { "from": "port", "name": "mainpanel_radar" } },
+  { "type": "hit", "data": { "from": "port", "name": "mainpanel_pilot" } },
+  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
+  { "type": "hit", "data": { "from": "port", "name": "player" } },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "location_senni-wreck" }
+  },
+  { "type": "pilotAligned", "data": "wreck" },
+  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
+  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
+  { "type": "hit", "data": { "from": "trigger", "name": "thruster_action" } },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  { "type": "docked", "data": "wreck" },
+  {
+    "type": "hit",
+    "data": {
+      "from": "port",
+      "numberlessName": "battery_slot_cell#",
+      "event": "battery-3"
+    }
+  },
+  { "type": "hit", "data": { "from": "port", "name": "battery_slot_radio" } },
+  { "type": "hit", "data": { "from": "port", "name": "widget_radio" } },
+  { "type": "hit", "data": { "from": "port", "name": "mainpanel_cargo" } },
+  { "type": "upload", "data": "cargo" },
+  { "type": "hit", "data": { "from": "port", "name": "senni-wreck_disk" } },
+  { "type": "hit", "data": { "from": "port", "name": "widget_radio" } },
+  { "type": "upload", "data": "widget_radio" },
+  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
+  { "type": "hit", "data": { "from": "port", "name": "player" } },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "location_senni-harvest" }
+  },
+  { "type": "pilotAligned", "data": "harvest" },
+  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
+  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
+  { "type": "hit", "data": { "from": "trigger", "name": "thruster_action" } },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  { "type": "docked", "data": "harvest" },
+  { "type": "hit", "data": { "from": "port", "name": "senni-harvest_eral" } },
+  { "type": "hit", "data": { "from": "port", "name": "mainpanel_cargo" } },
+  { "type": "upload", "data": "cargo" },
+  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
+  { "type": "hit", "data": { "from": "port", "name": "player" } },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "location_valen-Bank" }
+  },
+  { "type": "pilotAligned", "data": "Bank" },
+  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
+  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
+  { "type": "hit", "data": { "from": "trigger", "name": "thruster_action" } },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  { "type": "docked", "data": "Bank" },
+  {
+    "type": "hit",
+    "data": {
+      "from": "port",
+      "numberlessName": "console_line_#",
+      "event": "valen-key"
+    }
+  },
+  {
+    "type": "hit",
+    "data": {
+      "from": "port",
+      "numberlessName": "valen-Bank_slot_#",
+      "event": null
+    }
+  },
+  { "type": "upload", "data": "valen-Bank_slot_1" },
+  {
+    "type": "hit",
+    "data": {
+      "from": "port",
+      "numberlessName": "console_line_#",
+      "event": "loiqe-key"
+    }
+  },
+  {
+    "type": "hit",
+    "data": {
+      "from": "port",
+      "numberlessName": "valen-Bank_slot_#",
+      "event": null
+    }
+  },
+  { "type": "upload", "data": "valen-Bank_slot_2" },
+  {
+    "type": "hit",
+    "data": {
+      "from": "port",
+      "numberlessName": "console_line_#",
+      "event": "senni-key"
+    }
+  },
+  {
+    "type": "hit",
+    "data": {
+      "from": "port",
+      "numberlessName": "valen-Bank_slot_#",
+      "event": null
+    }
+  },
+  { "type": "upload", "data": "valen-Bank_slot_3" },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "location_valen-harvest" }
+  },
+  { "type": "pilotAligned", "data": "harvest" },
+  { "type": "hit", "data": { "from": "trigger", "name": "thruster_action" } },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  { "type": "docked", "data": "harvest" },
+  { "type": "hit", "data": { "from": "port", "name": "widget_radio" } },
+  { "type": "hit", "data": { "from": "port", "name": "mainpanel_cargo" } },
+  { "type": "upload", "data": "cargo" },
+  { "type": "hit", "data": { "from": "port", "name": "valen-harvest_ikov" } },
+  { "type": "hit", "data": { "from": "port", "name": "mainpanel_cargo" } },
+  { "type": "upload", "data": "cargo" },
+  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
+  { "type": "hit", "data": { "from": "port", "name": "player" } },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "location_senni-Horadric" }
+  },
+  { "type": "pilotAligned", "data": "Horadric" },
+  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
+  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
+  { "type": "hit", "data": { "from": "trigger", "name": "thruster_action" } },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  { "type": "docked", "data": "Horadric" },
+  {
+    "type": "hit",
+    "data": {
+      "from": "port",
+      "numberlessName": "console_line_#",
+      "event": null
+    }
+  },
+  {
+    "type": "hit",
+    "data": {
+      "from": "port",
+      "numberlessName": "senni-Horadric_input_#",
+      "event": null
+    }
+  },
+  { "type": "upload", "data": "senni-Horadric_input_2" },
+  {
+    "type": "hit",
+    "data": {
+      "from": "port",
+      "numberlessName": "console_line_#",
+      "event": null
+    }
+  },
+  {
+    "type": "hit",
+    "data": {
+      "from": "port",
+      "numberlessName": "senni-Horadric_input_#",
+      "event": null
+    }
+  },
+  { "type": "combination", "data": "ikeral" },
+  {
+    "type": "hit",
+    "data": { "from": "port", "name": "senni-Horadric_output_1" }
+  },
+  { "type": "hit", "data": { "from": "port", "name": "mainpanel_cargo" } },
+  { "type": "upload", "data": "cargo" },
+  {
+    "type": "hit",
+    "data": {
+      "from": "port",
+      "numberlessName": "console_line_#",
+      "event": "record1"
+    }
+  },
+  {
+    "type": "hit",
+    "data": {
+      "from": "port",
+      "numberlessName": "senni-Horadric_input_#",
+      "event": null
+    }
+  },
+  { "type": "upload", "data": "senni-Horadric_input_2" },
+  {
+    "type": "hit",
+    "data": {
+      "from": "port",
+      "numberlessName": "console_line_#",
+      "event": "record2"
+    }
+  },
+  {
+    "type": "hit",
+    "data": {
+      "from": "port",
+      "numberlessName": "senni-Horadric_input_#",
+      "event": null
+    }
+  },
+  { "type": "combination", "data": "cassette" },
+  {
+    "type": "hit",
+    "data": { "from": "port", "name": "senni-Horadric_output_1" }
+  },
+  { "type": "hit", "data": { "from": "port", "name": "widget_radio" } },
+  { "type": "upload", "data": "widget_radio" },
+  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
+  { "type": "hit", "data": { "from": "port", "name": "player" } },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "location_senni-fog" }
+  },
+  { "type": "pilotAligned", "data": "fog" },
+  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
+  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
+  { "type": "hit", "data": { "from": "trigger", "name": "thruster_action" } },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  { "type": "docked", "data": "fog" },
+  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
+  { "type": "hit", "data": { "from": "port", "name": "player" } },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "location_valen-portal" }
+  },
+  { "type": "pilotAligned", "data": "portal" },
+  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
+  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
+  { "type": "hit", "data": { "from": "trigger", "name": "thruster_action" } },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  { "type": "docked", "data": "portal" },
+  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
+  { "type": "hit", "data": { "from": "port", "name": "player" } },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "location_loiqe-portal" }
+  },
+  { "type": "pilotAligned", "data": "portal" },
+  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
+  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
+  { "type": "hit", "data": { "from": "trigger", "name": "thruster_action" } },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  { "type": "docked", "data": "portal" },
+  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
+  { "type": "hit", "data": { "from": "port", "name": "player" } },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "location_loiqe-fog" }
+  },
+  { "type": "pilotAligned", "data": "fog" },
+  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
+  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
+  { "type": "hit", "data": { "from": "trigger", "name": "thruster_action" } },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  { "type": "docked", "data": "fog" },
+  {
+    "type": "hit",
+    "data": {
+      "from": "port",
+      "numberlessName": "console_line_#",
+      "event": null
+    }
+  },
+  { "type": "hit", "data": { "from": "port", "name": "loiqe-fog_want" } },
+  { "type": "upload", "data": "loiqe-fog_want" },
+  { "type": "hit", "data": { "from": "port", "name": "loiqe-fog_give" } },
+  { "type": "hit", "data": { "from": "port", "name": "mainpanel_cargo" } },
+  { "type": "upload", "data": "cargo" },
+  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
+  { "type": "hit", "data": { "from": "port", "name": "player" } },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "location_loiqe-portal" }
+  },
+  { "type": "pilotAligned", "data": "portal" },
+  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
+  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
+  { "type": "hit", "data": { "from": "trigger", "name": "thruster_action" } },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  { "type": "docked", "data": "portal" },
+  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
+  { "type": "hit", "data": { "from": "port", "name": "player" } },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "location_loiqe-Horadric" }
+  },
+  { "type": "pilotAligned", "data": "Horadric" },
+  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
+  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
+  { "type": "hit", "data": { "from": "trigger", "name": "thruster_action" } },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  { "type": "docked", "data": "Horadric" },
+  {
+    "type": "hit",
+    "data": {
+      "from": "port",
+      "numberlessName": "console_line_#",
+      "event": "usul-key-1"
+    }
+  },
+  {
+    "type": "hit",
+    "data": {
+      "from": "port",
+      "numberlessName": "loiqe-Horadric_input_#",
+      "event": null
+    }
+  },
+  { "type": "upload", "data": "loiqe-Horadric_input_2" },
+  {
+    "type": "hit",
+    "data": {
+      "from": "port",
+      "numberlessName": "console_line_#",
+      "event": "usul-key-2"
+    }
+  },
+  {
+    "type": "hit",
+    "data": {
+      "from": "port",
+      "numberlessName": "loiqe-Horadric_input_#",
+      "event": null
+    }
+  },
+  { "type": "combination", "data": "usul key" },
+  {
+    "type": "hit",
+    "data": { "from": "port", "name": "loiqe-Horadric_output_1" }
+  },
+  { "type": "hit", "data": { "from": "port", "name": "mainpanel_cargo" } },
+  { "type": "upload", "data": "cargo" },
+  { "type": "hit", "data": { "from": "port", "name": "widget_radio" } },
+  { "type": "hit", "data": { "from": "port", "name": "mainpanel_cargo" } },
+  { "type": "upload", "data": "cargo" },
+  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
+  { "type": "hit", "data": { "from": "port", "name": "player" } },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "location_loiqe-portal" }
+  },
+  { "type": "pilotAligned", "data": "portal" },
+  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
+  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
+  { "type": "hit", "data": { "from": "trigger", "name": "thruster_action" } },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  { "type": "docked", "data": "portal" },
+  {
+    "type": "hit",
+    "data": {
+      "from": "port",
+      "numberlessName": "console_line_#",
+      "event": "usul-key"
+    }
+  },
+  { "type": "hit", "data": { "from": "port", "name": "mainpanel_mission" } },
+  {
+    "type": "hit",
+    "data": { "from": "port", "name": "loiqe-portal_thruster" }
+  },
+  { "type": "hit", "data": { "from": "port", "name": "mainpanel_thruster" } },
+  { "type": "hit", "data": { "from": "port", "name": "mainpanel_radar" } },
+  { "type": "hit", "data": { "from": "port", "name": "mainpanel_radar" } },
+  { "type": "hit", "data": { "from": "port", "name": "loiqe-portal_pilot" } },
+  { "type": "hit", "data": { "from": "port", "name": "mainpanel_pilot" } },
+  { "type": "pilotAligned", "data": "portal" },
+  { "type": "hit", "data": { "from": "trigger", "name": "thruster_action" } },
+  { "type": "docked", "data": "portal" },
+  { "type": "hit", "data": { "from": "port", "name": "mainpanel_radar" } },
+  { "type": "hit", "data": { "from": "port", "name": "mainpanel_pilot" } },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "location_usul-station" }
+  },
+  { "type": "hit", "data": { "from": "trigger", "name": "thruster_action" } },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  { "type": "docked", "data": "station" },
+  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
+  { "type": "hit", "data": { "from": "port", "name": "player" } },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "location_senni-transit" }
+  },
+  { "type": "pilotAligned", "data": "transit" },
+  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
+  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
+  { "type": "hit", "data": { "from": "trigger", "name": "thruster_action" } },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  { "type": "docked", "data": "transit" },
+  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
+  { "type": "hit", "data": { "from": "port", "name": "player" } },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "location_valen-Bank" }
+  },
+  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
+  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
+  { "type": "hit", "data": { "from": "trigger", "name": "thruster_action" } },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  { "type": "docked", "data": "Bank" },
+  {
+    "type": "hit",
+    "data": {
+      "from": "port",
+      "numberlessName": "console_line_#",
+      "event": "record3"
+    }
+  },
+  {
+    "type": "hit",
+    "data": {
+      "from": "port",
+      "numberlessName": "valen-Bank_slot_#",
+      "event": null
+    }
+  },
+  { "type": "upload", "data": "valen-Bank_slot_4" },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "location_valen-harvest" }
+  },
+  { "type": "pilotAligned", "data": "harvest" },
+  { "type": "hit", "data": { "from": "trigger", "name": "thruster_action" } },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  { "type": "docked", "data": "harvest" },
+  { "type": "hit", "data": { "from": "port", "name": "valen-harvest_ikov" } },
+  { "type": "hit", "data": { "from": "port", "name": "mainpanel_cargo" } },
+  { "type": "upload", "data": "cargo" },
+  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
+  { "type": "hit", "data": { "from": "port", "name": "player" } },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "location_senni-harvest" }
+  },
+  { "type": "pilotAligned", "data": "harvest" },
+  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
+  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
+  { "type": "hit", "data": { "from": "trigger", "name": "thruster_action" } },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  { "type": "docked", "data": "harvest" },
+  { "type": "hit", "data": { "from": "port", "name": "senni-harvest_eral" } },
+  { "type": "hit", "data": { "from": "port", "name": "mainpanel_cargo" } },
+  { "type": "upload", "data": "cargo" },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "location_senni-Horadric" }
+  },
+  { "type": "pilotAligned", "data": "Horadric" },
+  { "type": "hit", "data": { "from": "trigger", "name": "thruster_action" } },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  { "type": "docked", "data": "Horadric" },
+  {
+    "type": "hit",
+    "data": {
+      "from": "port",
+      "numberlessName": "console_line_#",
+      "event": null
+    }
+  },
+  {
+    "type": "hit",
+    "data": {
+      "from": "port",
+      "numberlessName": "senni-Horadric_input_#",
+      "event": null
+    }
+  },
+  { "type": "upload", "data": "senni-Horadric_input_2" },
+  {
+    "type": "hit",
+    "data": {
+      "from": "port",
+      "numberlessName": "console_line_#",
+      "event": null
+    }
+  },
+  {
+    "type": "hit",
+    "data": {
+      "from": "port",
+      "numberlessName": "senni-Horadric_input_#",
+      "event": null
+    }
+  },
+  { "type": "combination", "data": "ikeral" },
+  {
+    "type": "hit",
+    "data": { "from": "port", "name": "senni-Horadric_output_1" }
+  },
+  { "type": "hit", "data": { "from": "port", "name": "mainpanel_cargo" } },
+  { "type": "upload", "data": "cargo" },
+  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
+  { "type": "hit", "data": { "from": "port", "name": "player" } },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "location_senni-wreck" }
+  },
+  { "type": "pilotAligned", "data": "wreck" },
+  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
+  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
+  { "type": "hit", "data": { "from": "trigger", "name": "thruster_action" } },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  { "type": "docked", "data": "wreck" },
+  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
+  { "type": "hit", "data": { "from": "port", "name": "player" } },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "location_usul-station" }
+  },
+  { "type": "pilotAligned", "data": "station" },
+  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
+  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
+  { "type": "hit", "data": { "from": "trigger", "name": "thruster_action" } },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  { "type": "docked", "data": "station" },
+  {
+    "type": "hit",
+    "data": {
+      "from": "port",
+      "numberlessName": "console_line_#",
+      "event": null
+    }
+  },
+  { "type": "hit", "data": { "from": "port", "name": "usul-station" } },
+  { "type": "upload", "data": "usul-station" },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "button_usul-station_install" }
+  },
+  { "type": "mission", "data": 15 },
+  { "type": "playerUnlock", "data": 0 },
+  {
+    "type": "hit",
+    "data": {
+      "from": "port",
+      "numberlessName": "battery_slot_cell#",
+      "event": "battery-3"
+    }
+  },
+  { "type": "hit", "data": { "from": "port", "name": "battery_slot_oxygen" } },
+  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
+  { "type": "hit", "data": { "from": "port", "name": "player" } },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "location_valen-Bank" }
+  },
+  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
+  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
+  { "type": "hit", "data": { "from": "trigger", "name": "thruster_action" } },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  { "type": "docked", "data": "Bank" },
+  {
+    "type": "hit",
+    "data": {
+      "from": "port",
+      "numberlessName": "valen-Bank_slot_#",
+      "event": "valen-key"
+    }
+  },
+  { "type": "hit", "data": { "from": "port", "name": "mainpanel_cargo" } },
+  { "type": "upload", "data": "cargo" },
+  {
+    "type": "hit",
+    "data": {
+      "from": "port",
+      "numberlessName": "valen-Bank_slot_#",
+      "event": "loiqe-key"
+    }
+  },
+  { "type": "hit", "data": { "from": "port", "name": "mainpanel_cargo" } },
+  { "type": "upload", "data": "cargo" },
+  {
+    "type": "hit",
+    "data": {
+      "from": "port",
+      "numberlessName": "valen-Bank_slot_#",
+      "event": "senni-key"
+    }
+  },
+  { "type": "hit", "data": { "from": "port", "name": "mainpanel_cargo" } },
+  { "type": "upload", "data": "cargo" },
+  {
+    "type": "hit",
+    "data": {
+      "from": "port",
+      "numberlessName": "valen-Bank_slot_#",
+      "event": "record3"
+    }
+  },
+  { "type": "hit", "data": { "from": "port", "name": "mainpanel_cargo" } },
+  { "type": "upload", "data": "cargo" },
+  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
+  { "type": "hit", "data": { "from": "port", "name": "player" } },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "location_senni-Horadric" }
+  },
+  { "type": "pilotAligned", "data": "Horadric" },
+  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
+  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
+  { "type": "hit", "data": { "from": "trigger", "name": "thruster_action" } },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  { "type": "docked", "data": "Horadric" },
+  {
+    "type": "hit",
+    "data": {
+      "from": "port",
+      "numberlessName": "console_line_#",
+      "event": "usul-key"
+    }
+  },
+  {
+    "type": "hit",
+    "data": {
+      "from": "port",
+      "numberlessName": "senni-Horadric_input_#",
+      "event": null
+    }
+  },
+  { "type": "upload", "data": "senni-Horadric_input_2" },
+  {
+    "type": "hit",
+    "data": {
+      "from": "port",
+      "numberlessName": "console_line_#",
+      "event": "valen-key"
+    }
+  },
+  {
+    "type": "hit",
+    "data": {
+      "from": "port",
+      "numberlessName": "senni-Horadric_input_#",
+      "event": null
+    }
+  },
+  { "type": "combination", "data": "horizontal part" },
+  {
+    "type": "hit",
+    "data": { "from": "port", "name": "senni-Horadric_output_1" }
+  },
+  { "type": "hit", "data": { "from": "port", "name": "mainpanel_cargo" } },
+  { "type": "upload", "data": "cargo" },
+  {
+    "type": "hit",
+    "data": {
+      "from": "port",
+      "numberlessName": "console_line_#",
+      "event": "loiqe-key"
+    }
+  },
+  {
+    "type": "hit",
+    "data": {
+      "from": "port",
+      "numberlessName": "senni-Horadric_input_#",
+      "event": null
+    }
+  },
+  { "type": "upload", "data": "senni-Horadric_input_2" },
+  {
+    "type": "hit",
+    "data": {
+      "from": "port",
+      "numberlessName": "console_line_#",
+      "event": "senni-key"
+    }
+  },
+  {
+    "type": "hit",
+    "data": {
+      "from": "port",
+      "numberlessName": "senni-Horadric_input_#",
+      "event": null
+    }
+  },
+  { "type": "combination", "data": "vertical part" },
+  {
+    "type": "hit",
+    "data": { "from": "port", "name": "senni-Horadric_output_1" }
+  },
+  { "type": "hit", "data": { "from": "port", "name": "mainpanel_cargo" } },
+  { "type": "upload", "data": "cargo" },
+  {
+    "type": "hit",
+    "data": {
+      "from": "port",
+      "numberlessName": "console_line_#",
+      "event": "end-key-1"
+    }
+  },
+  {
+    "type": "hit",
+    "data": {
+      "from": "port",
+      "numberlessName": "senni-Horadric_input_#",
+      "event": null
+    }
+  },
+  { "type": "upload", "data": "senni-Horadric_input_2" },
+  {
+    "type": "hit",
+    "data": {
+      "from": "port",
+      "numberlessName": "console_line_#",
+      "event": "end-key-2"
+    }
+  },
+  {
+    "type": "hit",
+    "data": {
+      "from": "port",
+      "numberlessName": "senni-Horadric_input_#",
+      "event": null
+    }
+  },
+  { "type": "combination", "data": "End Key" },
+  {
+    "type": "hit",
+    "data": { "from": "port", "name": "senni-Horadric_output_1" }
+  },
+  { "type": "hit", "data": { "from": "port", "name": "mainpanel_cargo" } },
+  { "type": "upload", "data": "cargo" },
+  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
+  { "type": "hit", "data": { "from": "port", "name": "player" } },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "location_senni-wreck" }
+  },
+  { "type": "pilotAligned", "data": "wreck" },
+  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
+  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
+  { "type": "hit", "data": { "from": "trigger", "name": "thruster_action" } },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  { "type": "docked", "data": "wreck" },
+  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
+  { "type": "hit", "data": { "from": "port", "name": "player" } },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "location_usul-station" }
+  },
+  { "type": "pilotAligned", "data": "station" },
+  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
+  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
+  { "type": "hit", "data": { "from": "trigger", "name": "thruster_action" } },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  { "type": "docked", "data": "station" },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "location_usul-portal" }
+  },
+  { "type": "pilotAligned", "data": "portal" },
+  { "type": "hit", "data": { "from": "trigger", "name": "thruster_action" } },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  { "type": "docked", "data": "portal" },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "location_usul-telescope" }
+  },
+  { "type": "pilotAligned", "data": "telescope" },
+  { "type": "hit", "data": { "from": "trigger", "name": "thruster_action" } },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  { "type": "docked", "data": "telescope" },
+  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
+  { "type": "hit", "data": { "from": "port", "name": "mainpanel_cargo" } },
+  { "type": "upload", "data": "cargo" },
+  {
+    "type": "hit",
+    "data": { "from": "port", "name": "usul-telescope_Blind Map" }
+  },
+  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
+  { "type": "upload", "data": "widget_map" },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "location_usul-silence" }
+  },
+  { "type": "pilotAligned", "data": "silence" },
+  { "type": "hit", "data": { "from": "trigger", "name": "thruster_action" } },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  { "type": "docked", "data": "silence" },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "location_usul-annex" }
+  },
+  { "type": "pilotAligned", "data": "annex" },
+  { "type": "hit", "data": { "from": "trigger", "name": "thruster_action" } },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  { "type": "docked", "data": "annex" },
+  {
+    "type": "hit",
+    "data": {
+      "from": "port",
+      "numberlessName": "battery_slot_cell#",
+      "event": "battery-3"
+    }
+  },
+  { "type": "hit", "data": { "from": "port", "name": "battery_slot_radio" } },
+  { "type": "hit", "data": { "from": "port", "name": "usul-annex_drive" } },
+  { "type": "hit", "data": { "from": "port", "name": "widget_radio" } },
+  { "type": "upload", "data": "widget_radio" },
+  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
+  { "type": "hit", "data": { "from": "port", "name": "mainpanel_cargo" } },
+  { "type": "upload", "data": "cargo" },
+  {
+    "type": "hit",
+    "data": {
+      "from": "port",
+      "numberlessName": "console_line_#",
+      "event": "map-1"
+    }
+  },
+  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
+  { "type": "upload", "data": "widget_map" },
+  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
+  { "type": "hit", "data": { "from": "port", "name": "player" } },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "location_senni-transit" }
+  },
+  { "type": "pilotAligned", "data": "transit" },
+  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
+  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
+  { "type": "hit", "data": { "from": "trigger", "name": "thruster_action" } },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  { "type": "docked", "data": "transit" },
+  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
+  { "type": "hit", "data": { "from": "port", "name": "player" } },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "location_valen-Bank" }
+  },
+  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
+  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
+  { "type": "hit", "data": { "from": "trigger", "name": "thruster_action" } },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  { "type": "docked", "data": "Bank" },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "location_valen-harvest" }
+  },
+  { "type": "pilotAligned", "data": "harvest" },
+  { "type": "hit", "data": { "from": "trigger", "name": "thruster_action" } },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  { "type": "docked", "data": "harvest" },
+  { "type": "hit", "data": { "from": "port", "name": "valen-harvest_ikov" } },
+  { "type": "hit", "data": { "from": "port", "name": "mainpanel_cargo" } },
+  { "type": "upload", "data": "cargo" },
+  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
+  { "type": "hit", "data": { "from": "port", "name": "player" } },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "location_senni-harvest" }
+  },
+  { "type": "pilotAligned", "data": "harvest" },
+  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
+  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
+  { "type": "hit", "data": { "from": "trigger", "name": "thruster_action" } },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  { "type": "docked", "data": "harvest" },
+  { "type": "hit", "data": { "from": "port", "name": "senni-harvest_eral" } },
+  { "type": "hit", "data": { "from": "port", "name": "mainpanel_cargo" } },
+  { "type": "upload", "data": "cargo" },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "location_senni-Horadric" }
+  },
+  { "type": "pilotAligned", "data": "Horadric" },
+  { "type": "hit", "data": { "from": "trigger", "name": "thruster_action" } },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  { "type": "docked", "data": "Horadric" },
+  {
+    "type": "hit",
+    "data": {
+      "from": "port",
+      "numberlessName": "console_line_#",
+      "event": null
+    }
+  },
+  {
+    "type": "hit",
+    "data": {
+      "from": "port",
+      "numberlessName": "senni-Horadric_input_#",
+      "event": null
+    }
+  },
+  { "type": "upload", "data": "senni-Horadric_input_2" },
+  {
+    "type": "hit",
+    "data": {
+      "from": "port",
+      "numberlessName": "console_line_#",
+      "event": null
+    }
+  },
+  {
+    "type": "hit",
+    "data": {
+      "from": "port",
+      "numberlessName": "senni-Horadric_input_#",
+      "event": null
+    }
+  },
+  { "type": "combination", "data": "ikeral" },
+  {
+    "type": "hit",
+    "data": { "from": "port", "name": "senni-Horadric_output_1" }
+  },
+  { "type": "hit", "data": { "from": "port", "name": "mainpanel_cargo" } },
+  { "type": "upload", "data": "cargo" },
+  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
+  { "type": "hit", "data": { "from": "port", "name": "player" } },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "location_valen-harvest" }
+  },
+  { "type": "pilotAligned", "data": "harvest" },
+  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
+  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
+  { "type": "hit", "data": { "from": "trigger", "name": "thruster_action" } },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  { "type": "docked", "data": "harvest" },
+  { "type": "hit", "data": { "from": "port", "name": "valen-harvest_ikov" } },
+  { "type": "hit", "data": { "from": "port", "name": "mainpanel_cargo" } },
+  { "type": "upload", "data": "cargo" },
+  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
+  { "type": "hit", "data": { "from": "port", "name": "player" } },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "location_loiqe-portal" }
+  },
+  { "type": "pilotAligned", "data": "portal" },
+  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
+  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
+  { "type": "hit", "data": { "from": "trigger", "name": "thruster_action" } },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  { "type": "docked", "data": "portal" },
+  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
+  { "type": "hit", "data": { "from": "port", "name": "player" } },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "location_loiqe-port" }
+  },
+  { "type": "pilotAligned", "data": "port" },
+  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
+  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
+  { "type": "hit", "data": { "from": "trigger", "name": "thruster_action" } },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  { "type": "docked", "data": "port" },
+  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
+  { "type": "hit", "data": { "from": "port", "name": "player" } },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "location_loiqe-Harvest" }
+  },
+  { "type": "pilotAligned", "data": "Harvest" },
+  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
+  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  { "type": "docked", "data": "Harvest" },
+  { "type": "hit", "data": { "from": "port", "name": "loiqe-Harvest_alta" } },
+  { "type": "hit", "data": { "from": "port", "name": "mainpanel_cargo" } },
+  { "type": "upload", "data": "cargo" },
+  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
+  { "type": "hit", "data": { "from": "port", "name": "player" } },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "location_loiqe-Horadric" }
+  },
+  { "type": "pilotAligned", "data": "Horadric" },
+  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
+  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
+  { "type": "hit", "data": { "from": "trigger", "name": "thruster_action" } },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  { "type": "docked", "data": "Horadric" },
+  {
+    "type": "hit",
+    "data": {
+      "from": "port",
+      "numberlessName": "console_line_#",
+      "event": null
+    }
+  },
+  {
+    "type": "hit",
+    "data": {
+      "from": "port",
+      "numberlessName": "loiqe-Horadric_input_#",
+      "event": null
+    }
+  },
+  { "type": "upload", "data": "loiqe-Horadric_input_2" },
+  {
+    "type": "hit",
+    "data": {
+      "from": "port",
+      "numberlessName": "console_line_#",
+      "event": null
+    }
+  },
+  {
+    "type": "hit",
+    "data": {
+      "from": "port",
+      "numberlessName": "loiqe-Horadric_input_#",
+      "event": null
+    }
+  },
+  { "type": "combination", "data": "altiov" },
+  {
+    "type": "hit",
+    "data": { "from": "port", "name": "loiqe-Horadric_output_1" }
+  },
+  { "type": "hit", "data": { "from": "port", "name": "mainpanel_cargo" } },
+  { "type": "upload", "data": "cargo" },
+  {
+    "type": "hit",
+    "data": {
+      "from": "port",
+      "numberlessName": "console_line_#",
+      "event": null
+    }
+  },
+  {
+    "type": "hit",
+    "data": {
+      "from": "port",
+      "numberlessName": "loiqe-Horadric_input_#",
+      "event": null
+    }
+  },
+  { "type": "upload", "data": "loiqe-Horadric_input_2" },
+  {
+    "type": "hit",
+    "data": {
+      "from": "port",
+      "numberlessName": "console_line_#",
+      "event": null
+    }
+  },
+  {
+    "type": "hit",
+    "data": {
+      "from": "port",
+      "numberlessName": "loiqe-Horadric_input_#",
+      "event": null
+    }
+  },
+  { "type": "combination", "data": "echo" },
+  {
+    "type": "hit",
+    "data": { "from": "port", "name": "loiqe-Horadric_output_1" }
+  },
+  { "type": "hit", "data": { "from": "port", "name": "mainpanel_cargo" } },
+  { "type": "upload", "data": "cargo" },
+  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
+  { "type": "hit", "data": { "from": "port", "name": "player" } },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "location_usul-station" }
+  },
+  { "type": "pilotAligned", "data": "station" },
+  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
+  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
+  { "type": "hit", "data": { "from": "trigger", "name": "thruster_action" } },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  { "type": "docked", "data": "station" },
+  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
+  { "type": "hit", "data": { "from": "port", "name": "mainpanel_cargo" } },
+  { "type": "upload", "data": "cargo" },
+  {
+    "type": "hit",
+    "data": {
+      "from": "port",
+      "numberlessName": "console_line_#",
+      "event": "map-2"
+    }
+  },
+  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
+  { "type": "upload", "data": "widget_map" },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "location_usul-silence" }
+  },
+  { "type": "pilotAligned", "data": "silence" },
+  { "type": "hit", "data": { "from": "trigger", "name": "thruster_action" } },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  { "type": "docked", "data": "silence" },
+  {
+    "type": "hit",
+    "data": {
+      "from": "port",
+      "numberlessName": "console_line_#",
+      "event": null
+    }
+  },
+  { "type": "hit", "data": { "from": "port", "name": "usul-silence_want" } },
+  { "type": "upload", "data": "usul-silence_want" },
+  { "type": "hit", "data": { "from": "port", "name": "usul-silence_give" } },
+  { "type": "hit", "data": { "from": "port", "name": "mainpanel_cargo" } },
+  { "type": "upload", "data": "cargo" },
+  { "type": "hit", "data": { "from": "port", "name": "widget_radio" } },
+  { "type": "hit", "data": { "from": "port", "name": "mainpanel_cargo" } },
+  { "type": "upload", "data": "cargo" },
+  {
+    "type": "hit",
+    "data": {
+      "from": "port",
+      "numberlessName": "battery_slot_cell#",
+      "event": "battery-3"
+    }
+  },
+  { "type": "hit", "data": { "from": "port", "name": "battery_slot_oxygen" } },
+  {
+    "type": "hit",
+    "data": {
+      "from": "port",
+      "numberlessName": "console_line_#",
+      "event": "shield-1"
+    }
+  },
+  { "type": "hit", "data": { "from": "port", "name": "widget_shield" } },
+  { "type": "mission", "data": 17 },
+  { "type": "upload", "data": "widget_shield" },
+  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
+  { "type": "hit", "data": { "from": "port", "name": "player" } },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "location_loiqe-portal" }
+  },
+  { "type": "pilotAligned", "data": "portal" },
+  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
+  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
+  { "type": "hit", "data": { "from": "trigger", "name": "thruster_action" } },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  { "type": "docked", "data": "portal" },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "location_loiqe-Loiqe" }
+  },
+  { "type": "pilotAligned", "data": "Loiqe" },
+  { "type": "hit", "data": { "from": "trigger", "name": "thruster_action" } },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  { "type": "docked", "data": "Loiqe" },
+  {
+    "type": "hit",
+    "data": {
+      "from": "port",
+      "numberlessName": "console_line_#",
+      "event": "end-key"
+    }
+  },
+  { "type": "hit", "data": { "from": "port", "name": "loiqe-Loiqe" } },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "button_loiqe-Loiqe_install" }
+  },
+  { "type": "pilotAligned", "data": "Loiqe" },
+  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
+  { "type": "hit", "data": { "from": "port", "name": "player" } },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "location_loiqe-spawn" }
+  },
+  { "type": "pilotAligned", "data": "spawn" },
+  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
+  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
+  { "type": "hit", "data": { "from": "trigger", "name": "thruster_action" } },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  { "type": "docked", "data": "spawn" },
+  { "type": "hit", "data": { "from": "port", "name": "loiqe-spawn_a teapot" } },
+  { "type": "hit", "data": { "from": "port", "name": "mainpanel_cargo" } },
+  { "type": "upload", "data": "cargo" },
+  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
+  { "type": "hit", "data": { "from": "port", "name": "player" } },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "location_loiqe-satellite" }
+  },
+  { "type": "pilotAligned", "data": "satellite" },
+  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
+  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
+  { "type": "hit", "data": { "from": "trigger", "name": "thruster_action" } },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  { "type": "docked", "data": "satellite" },
+  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
+  { "type": "hit", "data": { "from": "port", "name": "player" } },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "location_valen-void" }
+  },
+  { "type": "pilotAligned", "data": "void" },
+  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
+  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
+  { "type": "hit", "data": { "from": "trigger", "name": "thruster_action" } },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  { "type": "docked", "data": "void" },
+  {
+    "type": "hit",
+    "data": {
+      "from": "port",
+      "numberlessName": "console_line_#",
+      "event": "echoes-1"
+    }
+  },
+  { "type": "hit", "data": { "from": "port", "name": "valen-void_want" } },
+  { "type": "upload", "data": "valen-void_want" },
+  { "type": "hit", "data": { "from": "port", "name": "valen-void_give" } },
+  { "type": "hit", "data": { "from": "port", "name": "mainpanel_cargo" } },
+  { "type": "upload", "data": "cargo" },
+  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
+  { "type": "hit", "data": { "from": "port", "name": "player" } },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "location_valen-Valen" }
+  },
+  { "type": "pilotAligned", "data": "Valen" },
+  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
+  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
+  { "type": "hit", "data": { "from": "trigger", "name": "thruster_action" } },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  { "type": "docked", "data": "Valen" },
+  {
+    "type": "hit",
+    "data": {
+      "from": "port",
+      "numberlessName": "console_line_#",
+      "event": "end-key"
+    }
+  },
+  { "type": "hit", "data": { "from": "port", "name": "valen-Valen" } },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "button_valen-Valen_install" }
+  },
+  { "type": "pilotAligned", "data": "Valen" },
+  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
+  { "type": "hit", "data": { "from": "port", "name": "player" } },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "location_senni-bog" }
+  },
+  { "type": "pilotAligned", "data": "bog" },
+  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
+  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
+  { "type": "hit", "data": { "from": "trigger", "name": "thruster_action" } },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  { "type": "docked", "data": "bog" },
+  {
+    "type": "hit",
+    "data": {
+      "from": "port",
+      "numberlessName": "console_line_#",
+      "event": "kelp"
+    }
+  },
+  { "type": "hit", "data": { "from": "port", "name": "senni-bog_want" } },
+  { "type": "upload", "data": "senni-bog_want" },
+  { "type": "hit", "data": { "from": "port", "name": "senni-bog_give" } },
+  { "type": "hit", "data": { "from": "port", "name": "mainpanel_cargo" } },
+  { "type": "upload", "data": "cargo" },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "location_senni-Senni" }
+  },
+  { "type": "pilotAligned", "data": "Senni" },
+  { "type": "hit", "data": { "from": "trigger", "name": "thruster_action" } },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  { "type": "docked", "data": "Senni" },
+  {
+    "type": "hit",
+    "data": {
+      "from": "port",
+      "numberlessName": "console_line_#",
+      "event": "end-key"
+    }
+  },
+  { "type": "hit", "data": { "from": "port", "name": "senni-Senni" } },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "button_senni-Senni_install" }
+  },
+  { "type": "pilotAligned", "data": "Senni" },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "location_senni-cargo" }
+  },
+  { "type": "pilotAligned", "data": "cargo" },
+  { "type": "hit", "data": { "from": "trigger", "name": "thruster_action" } },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  { "type": "docked", "data": "cargo" },
+  {
+    "type": "hit",
+    "data": {
+      "from": "port",
+      "numberlessName": "battery_slot_cell#",
+      "event": "battery-3"
+    }
+  },
+  { "type": "hit", "data": { "from": "port", "name": "battery_slot_radio" } },
+  {
+    "type": "hit",
+    "data": {
+      "from": "port",
+      "numberlessName": "console_line_#",
+      "event": "record5"
+    }
+  },
+  { "type": "hit", "data": { "from": "port", "name": "widget_radio" } },
+  { "type": "upload", "data": "widget_radio" },
+  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
+  { "type": "hit", "data": { "from": "port", "name": "player" } },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "location_usul-annex" }
+  },
+  { "type": "pilotAligned", "data": "annex" },
+  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
+  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
+  { "type": "hit", "data": { "from": "trigger", "name": "thruster_action" } },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  { "type": "docked", "data": "annex" },
+  {
+    "type": "hit",
+    "data": {
+      "from": "port",
+      "numberlessName": "battery_slot_cell#",
+      "event": "battery-3"
+    }
+  },
+  { "type": "hit", "data": { "from": "port", "name": "battery_slot_oxygen" } },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "location_usul-Usul" }
+  },
+  { "type": "pilotAligned", "data": "Usul" },
+  { "type": "hit", "data": { "from": "trigger", "name": "thruster_action" } },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  { "type": "docked", "data": "Usul" },
+  {
+    "type": "hit",
+    "data": {
+      "from": "port",
+      "numberlessName": "console_line_#",
+      "event": "end-key"
+    }
+  },
+  { "type": "hit", "data": { "from": "port", "name": "usul-Usul" } },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "button_usul-Usul_install" }
+  },
+  { "type": "mission", "data": 18 },
+  { "type": "pilotAligned", "data": "Usul" },
+  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
+  { "type": "hit", "data": { "from": "port", "name": "mainpanel_cargo" } },
+  { "type": "upload", "data": "cargo" },
+  {
+    "type": "hit",
+    "data": {
+      "from": "port",
+      "numberlessName": "console_line_#",
+      "event": "map-1"
+    }
+  },
+  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
+  { "type": "upload", "data": "widget_map" },
+  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
+  { "type": "hit", "data": { "from": "port", "name": "player" } },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "location_usul-transit" }
+  },
+  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
+  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
+  { "type": "hit", "data": { "from": "trigger", "name": "thruster_action" } },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  { "type": "docked", "data": "transit" },
+  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
+  { "type": "hit", "data": { "from": "port", "name": "mainpanel_cargo" } },
+  { "type": "upload", "data": "cargo" },
+  {
+    "type": "hit",
+    "data": {
+      "from": "port",
+      "numberlessName": "console_line_#",
+      "event": "map-2"
+    }
+  },
+  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
+  { "type": "upload", "data": "widget_map" },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "location_close-close" }
+  },
+  { "type": "hit", "data": { "from": "trigger", "name": "thruster_action" } },
+  {
+    "type": "hit",
+    "data": { "from": "trigger", "name": "thruster_accelerate" }
+  },
+  { "type": "mission", "data": 19 }
+]

--- a/verreciel_js/media/walkthrough.json
+++ b/verreciel_js/media/walkthrough.json
@@ -325,7 +325,7 @@
     "type": "hit"
   },
   {
-    "data": "valen key",
+    "data": "valen-key",
     "index": 46,
     "type": "combination"
   },
@@ -1510,7 +1510,7 @@
     "type": "hit"
   },
   {
-    "data": "altiov",
+    "data": "currency-4",
     "index": 211,
     "type": "combination"
   },
@@ -3447,7 +3447,7 @@
     "type": "hit"
   },
   {
-    "data": "ikeral",
+    "data": "currency-5",
     "index": 475,
     "type": "combination"
   },
@@ -3514,7 +3514,7 @@
     "type": "hit"
   },
   {
-    "data": "cassette",
+    "data": "record3",
     "index": 484,
     "type": "combination"
   },
@@ -4116,7 +4116,7 @@
     "type": "hit"
   },
   {
-    "data": "usul key",
+    "data": "usul-key",
     "index": 565,
     "type": "combination"
   },
@@ -4836,7 +4836,7 @@
     "type": "hit"
   },
   {
-    "data": "ikeral",
+    "data": "currency-5",
     "index": 662,
     "type": "combination"
   },
@@ -5506,7 +5506,7 @@
     "type": "hit"
   },
   {
-    "data": "End Key",
+    "data": "end-key",
     "index": 752,
     "type": "combination"
   },
@@ -6443,7 +6443,7 @@
     "type": "hit"
   },
   {
-    "data": "ikeral",
+    "data": "currency-5",
     "index": 880,
     "type": "combination"
   },
@@ -6783,7 +6783,7 @@
   {
     "data": {
       "from": "trigger",
-      "name": "thruster_accelerate"
+      "name": "thruster_action"
     },
     "index": 926,
     "type": "hit"
@@ -6805,8 +6805,16 @@
     "type": "hit"
   },
   {
-    "data": "Harvest",
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
     "index": 929,
+    "type": "hit"
+  },
+  {
+    "data": "Harvest",
+    "index": 930,
     "type": "docked"
   },
   {
@@ -6814,7 +6822,7 @@
       "from": "port",
       "name": "loiqe-Harvest_alta"
     },
-    "index": 930,
+    "index": 931,
     "type": "hit"
   },
   {
@@ -6822,12 +6830,12 @@
       "from": "port",
       "name": "mainpanel_cargo"
     },
-    "index": 931,
+    "index": 932,
     "type": "hit"
   },
   {
     "data": "cargo",
-    "index": 932,
+    "index": 933,
     "type": "upload"
   },
   {
@@ -6835,7 +6843,7 @@
       "from": "port",
       "name": "widget_map"
     },
-    "index": 933,
+    "index": 934,
     "type": "hit"
   },
   {
@@ -6843,7 +6851,7 @@
       "from": "port",
       "name": "player"
     },
-    "index": 934,
+    "index": 935,
     "type": "hit"
   },
   {
@@ -6851,21 +6859,13 @@
       "from": "trigger",
       "name": "location_loiqe-Horadric"
     },
-    "index": 935,
+    "index": 936,
     "type": "hit"
   },
   {
     "data": "Horadric",
-    "index": 936,
-    "type": "pilotAligned"
-  },
-  {
-    "data": {
-      "from": "port",
-      "name": "widget_map"
-    },
     "index": 937,
-    "type": "hit"
+    "type": "pilotAligned"
   },
   {
     "data": {
@@ -6877,8 +6877,8 @@
   },
   {
     "data": {
-      "from": "trigger",
-      "name": "thruster_action"
+      "from": "port",
+      "name": "widget_map"
     },
     "index": 939,
     "type": "hit"
@@ -6886,7 +6886,7 @@
   {
     "data": {
       "from": "trigger",
-      "name": "thruster_accelerate"
+      "name": "thruster_action"
     },
     "index": 940,
     "type": "hit"
@@ -6908,8 +6908,16 @@
     "type": "hit"
   },
   {
-    "data": "Horadric",
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
     "index": 943,
+    "type": "hit"
+  },
+  {
+    "data": "Horadric",
+    "index": 944,
     "type": "docked"
   },
   {
@@ -6918,7 +6926,7 @@
       "from": "port",
       "numberlessName": "console_line_#"
     },
-    "index": 944,
+    "index": 945,
     "type": "hit"
   },
   {
@@ -6927,12 +6935,12 @@
       "from": "port",
       "numberlessName": "loiqe-Horadric_input_#"
     },
-    "index": 945,
+    "index": 946,
     "type": "hit"
   },
   {
     "data": "loiqe-Horadric_input_#",
-    "index": 946,
+    "index": 947,
     "type": "upload"
   },
   {
@@ -6941,7 +6949,7 @@
       "from": "port",
       "numberlessName": "console_line_#"
     },
-    "index": 947,
+    "index": 948,
     "type": "hit"
   },
   {
@@ -6950,12 +6958,12 @@
       "from": "port",
       "numberlessName": "loiqe-Horadric_input_#"
     },
-    "index": 948,
+    "index": 949,
     "type": "hit"
   },
   {
-    "data": "altiov",
-    "index": 949,
+    "data": "currency-4",
+    "index": 950,
     "type": "combination"
   },
   {
@@ -6963,7 +6971,7 @@
       "from": "port",
       "name": "loiqe-Horadric_output_1"
     },
-    "index": 950,
+    "index": 951,
     "type": "hit"
   },
   {
@@ -6971,12 +6979,12 @@
       "from": "port",
       "name": "mainpanel_cargo"
     },
-    "index": 951,
+    "index": 952,
     "type": "hit"
   },
   {
     "data": "cargo",
-    "index": 952,
+    "index": 953,
     "type": "upload"
   },
   {
@@ -6985,7 +6993,7 @@
       "from": "port",
       "numberlessName": "console_line_#"
     },
-    "index": 953,
+    "index": 954,
     "type": "hit"
   },
   {
@@ -6994,12 +7002,12 @@
       "from": "port",
       "numberlessName": "loiqe-Horadric_input_#"
     },
-    "index": 954,
+    "index": 955,
     "type": "hit"
   },
   {
     "data": "loiqe-Horadric_input_#",
-    "index": 955,
+    "index": 956,
     "type": "upload"
   },
   {
@@ -7008,7 +7016,7 @@
       "from": "port",
       "numberlessName": "console_line_#"
     },
-    "index": 956,
+    "index": 957,
     "type": "hit"
   },
   {
@@ -7017,12 +7025,12 @@
       "from": "port",
       "numberlessName": "loiqe-Horadric_input_#"
     },
-    "index": 957,
+    "index": 958,
     "type": "hit"
   },
   {
-    "data": "echo",
-    "index": 958,
+    "data": "currency-6",
+    "index": 959,
     "type": "combination"
   },
   {
@@ -7030,7 +7038,7 @@
       "from": "port",
       "name": "loiqe-Horadric_output_1"
     },
-    "index": 959,
+    "index": 960,
     "type": "hit"
   },
   {
@@ -7038,12 +7046,12 @@
       "from": "port",
       "name": "mainpanel_cargo"
     },
-    "index": 960,
+    "index": 961,
     "type": "hit"
   },
   {
     "data": "cargo",
-    "index": 961,
+    "index": 962,
     "type": "upload"
   },
   {
@@ -7051,7 +7059,7 @@
       "from": "port",
       "name": "widget_map"
     },
-    "index": 962,
+    "index": 963,
     "type": "hit"
   },
   {
@@ -7059,7 +7067,7 @@
       "from": "port",
       "name": "player"
     },
-    "index": 963,
+    "index": 964,
     "type": "hit"
   },
   {
@@ -7067,21 +7075,13 @@
       "from": "trigger",
       "name": "location_usul-station"
     },
-    "index": 964,
+    "index": 965,
     "type": "hit"
   },
   {
     "data": "station",
-    "index": 965,
-    "type": "pilotAligned"
-  },
-  {
-    "data": {
-      "from": "port",
-      "name": "widget_map"
-    },
     "index": 966,
-    "type": "hit"
+    "type": "pilotAligned"
   },
   {
     "data": {
@@ -7093,8 +7093,8 @@
   },
   {
     "data": {
-      "from": "trigger",
-      "name": "thruster_action"
+      "from": "port",
+      "name": "widget_map"
     },
     "index": 968,
     "type": "hit"
@@ -7102,7 +7102,7 @@
   {
     "data": {
       "from": "trigger",
-      "name": "thruster_accelerate"
+      "name": "thruster_action"
     },
     "index": 969,
     "type": "hit"
@@ -7124,8 +7124,16 @@
     "type": "hit"
   },
   {
-    "data": "station",
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
     "index": 972,
+    "type": "hit"
+  },
+  {
+    "data": "station",
+    "index": 973,
     "type": "docked"
   },
   {
@@ -7133,7 +7141,7 @@
       "from": "port",
       "name": "widget_map"
     },
-    "index": 973,
+    "index": 974,
     "type": "hit"
   },
   {
@@ -7141,12 +7149,12 @@
       "from": "port",
       "name": "mainpanel_cargo"
     },
-    "index": 974,
+    "index": 975,
     "type": "hit"
   },
   {
     "data": "cargo",
-    "index": 975,
+    "index": 976,
     "type": "upload"
   },
   {
@@ -7155,7 +7163,7 @@
       "from": "port",
       "numberlessName": "console_line_#"
     },
-    "index": 976,
+    "index": 977,
     "type": "hit"
   },
   {
@@ -7163,12 +7171,12 @@
       "from": "port",
       "name": "widget_map"
     },
-    "index": 977,
+    "index": 978,
     "type": "hit"
   },
   {
     "data": "widget_map",
-    "index": 978,
+    "index": 979,
     "type": "upload"
   },
   {
@@ -7176,26 +7184,18 @@
       "from": "trigger",
       "name": "location_usul-silence"
     },
-    "index": 979,
+    "index": 980,
     "type": "hit"
   },
   {
     "data": "silence",
-    "index": 980,
+    "index": 981,
     "type": "pilotAligned"
   },
   {
     "data": {
       "from": "trigger",
       "name": "thruster_action"
-    },
-    "index": 981,
-    "type": "hit"
-  },
-  {
-    "data": {
-      "from": "trigger",
-      "name": "thruster_accelerate"
     },
     "index": 982,
     "type": "hit"
@@ -7217,8 +7217,16 @@
     "type": "hit"
   },
   {
-    "data": "silence",
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
     "index": 985,
+    "type": "hit"
+  },
+  {
+    "data": "silence",
+    "index": 986,
     "type": "docked"
   },
   {
@@ -7227,7 +7235,7 @@
       "from": "port",
       "numberlessName": "console_line_#"
     },
-    "index": 986,
+    "index": 987,
     "type": "hit"
   },
   {
@@ -7235,12 +7243,12 @@
       "from": "port",
       "name": "usul-silence_want"
     },
-    "index": 987,
+    "index": 988,
     "type": "hit"
   },
   {
     "data": "usul-silence_want",
-    "index": 988,
+    "index": 989,
     "type": "upload"
   },
   {
@@ -7248,7 +7256,7 @@
       "from": "port",
       "name": "usul-silence_give"
     },
-    "index": 989,
+    "index": 990,
     "type": "hit"
   },
   {
@@ -7256,12 +7264,12 @@
       "from": "port",
       "name": "mainpanel_cargo"
     },
-    "index": 990,
+    "index": 991,
     "type": "hit"
   },
   {
     "data": "cargo",
-    "index": 991,
+    "index": 992,
     "type": "upload"
   },
   {
@@ -7269,7 +7277,7 @@
       "from": "port",
       "name": "widget_radio"
     },
-    "index": 992,
+    "index": 993,
     "type": "hit"
   },
   {
@@ -7277,12 +7285,12 @@
       "from": "port",
       "name": "mainpanel_cargo"
     },
-    "index": 993,
+    "index": 994,
     "type": "hit"
   },
   {
     "data": "cargo",
-    "index": 994,
+    "index": 995,
     "type": "upload"
   },
   {
@@ -7291,7 +7299,7 @@
       "from": "port",
       "numberlessName": "battery_slot_cell#"
     },
-    "index": 995,
+    "index": 996,
     "type": "hit"
   },
   {
@@ -7299,7 +7307,7 @@
       "from": "port",
       "name": "battery_slot_oxygen"
     },
-    "index": 996,
+    "index": 997,
     "type": "hit"
   },
   {
@@ -7308,7 +7316,7 @@
       "from": "port",
       "numberlessName": "console_line_#"
     },
-    "index": 997,
+    "index": 998,
     "type": "hit"
   },
   {
@@ -7316,18 +7324,18 @@
       "from": "port",
       "name": "widget_shield"
     },
-    "index": 998,
+    "index": 999,
     "type": "hit"
   },
   {
     "data": 17,
-    "index": 999,
+    "index": 1000,
     "skip": true,
     "type": "mission"
   },
   {
     "data": "widget_shield",
-    "index": 1000,
+    "index": 1001,
     "type": "upload"
   },
   {
@@ -7335,7 +7343,7 @@
       "from": "port",
       "name": "widget_map"
     },
-    "index": 1001,
+    "index": 1002,
     "type": "hit"
   },
   {
@@ -7343,7 +7351,7 @@
       "from": "port",
       "name": "player"
     },
-    "index": 1002,
+    "index": 1003,
     "type": "hit"
   },
   {
@@ -7351,21 +7359,13 @@
       "from": "trigger",
       "name": "location_loiqe-portal"
     },
-    "index": 1003,
+    "index": 1004,
     "type": "hit"
   },
   {
     "data": "portal",
-    "index": 1004,
-    "type": "pilotAligned"
-  },
-  {
-    "data": {
-      "from": "port",
-      "name": "widget_map"
-    },
     "index": 1005,
-    "type": "hit"
+    "type": "pilotAligned"
   },
   {
     "data": {
@@ -7377,8 +7377,8 @@
   },
   {
     "data": {
-      "from": "trigger",
-      "name": "thruster_action"
+      "from": "port",
+      "name": "widget_map"
     },
     "index": 1007,
     "type": "hit"
@@ -7386,7 +7386,7 @@
   {
     "data": {
       "from": "trigger",
-      "name": "thruster_accelerate"
+      "name": "thruster_action"
     },
     "index": 1008,
     "type": "hit"
@@ -7408,8 +7408,16 @@
     "type": "hit"
   },
   {
-    "data": "portal",
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
     "index": 1011,
+    "type": "hit"
+  },
+  {
+    "data": "portal",
+    "index": 1012,
     "type": "docked"
   },
   {
@@ -7417,26 +7425,18 @@
       "from": "trigger",
       "name": "location_loiqe-Loiqe"
     },
-    "index": 1012,
+    "index": 1013,
     "type": "hit"
   },
   {
     "data": "Loiqe",
-    "index": 1013,
+    "index": 1014,
     "type": "pilotAligned"
   },
   {
     "data": {
       "from": "trigger",
       "name": "thruster_action"
-    },
-    "index": 1014,
-    "type": "hit"
-  },
-  {
-    "data": {
-      "from": "trigger",
-      "name": "thruster_accelerate"
     },
     "index": 1015,
     "type": "hit"
@@ -7458,8 +7458,16 @@
     "type": "hit"
   },
   {
-    "data": "Loiqe",
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
     "index": 1018,
+    "type": "hit"
+  },
+  {
+    "data": "Loiqe",
+    "index": 1019,
     "type": "docked"
   },
   {
@@ -7468,7 +7476,7 @@
       "from": "port",
       "numberlessName": "console_line_#"
     },
-    "index": 1019,
+    "index": 1020,
     "type": "hit"
   },
   {
@@ -7476,7 +7484,7 @@
       "from": "port",
       "name": "loiqe-Loiqe"
     },
-    "index": 1020,
+    "index": 1021,
     "type": "hit"
   },
   {
@@ -7484,12 +7492,12 @@
       "from": "trigger",
       "name": "button_loiqe-Loiqe_install"
     },
-    "index": 1021,
+    "index": 1022,
     "type": "hit"
   },
   {
     "data": "Loiqe",
-    "index": 1022,
+    "index": 1023,
     "type": "pilotAligned"
   },
   {
@@ -7497,7 +7505,7 @@
       "from": "port",
       "name": "widget_map"
     },
-    "index": 1023,
+    "index": 1024,
     "type": "hit"
   },
   {
@@ -7505,7 +7513,7 @@
       "from": "port",
       "name": "player"
     },
-    "index": 1024,
+    "index": 1025,
     "type": "hit"
   },
   {
@@ -7513,21 +7521,13 @@
       "from": "trigger",
       "name": "location_loiqe-spawn"
     },
-    "index": 1025,
+    "index": 1026,
     "type": "hit"
   },
   {
     "data": "spawn",
-    "index": 1026,
-    "type": "pilotAligned"
-  },
-  {
-    "data": {
-      "from": "port",
-      "name": "widget_map"
-    },
     "index": 1027,
-    "type": "hit"
+    "type": "pilotAligned"
   },
   {
     "data": {
@@ -7539,8 +7539,8 @@
   },
   {
     "data": {
-      "from": "trigger",
-      "name": "thruster_action"
+      "from": "port",
+      "name": "widget_map"
     },
     "index": 1029,
     "type": "hit"
@@ -7548,7 +7548,7 @@
   {
     "data": {
       "from": "trigger",
-      "name": "thruster_accelerate"
+      "name": "thruster_action"
     },
     "index": 1030,
     "type": "hit"
@@ -7570,8 +7570,16 @@
     "type": "hit"
   },
   {
-    "data": "spawn",
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
     "index": 1033,
+    "type": "hit"
+  },
+  {
+    "data": "spawn",
+    "index": 1034,
     "type": "docked"
   },
   {
@@ -7579,7 +7587,7 @@
       "from": "port",
       "name": "loiqe-spawn_a teapot"
     },
-    "index": 1034,
+    "index": 1035,
     "type": "hit"
   },
   {
@@ -7587,12 +7595,12 @@
       "from": "port",
       "name": "mainpanel_cargo"
     },
-    "index": 1035,
+    "index": 1036,
     "type": "hit"
   },
   {
     "data": "cargo",
-    "index": 1036,
+    "index": 1037,
     "type": "upload"
   },
   {
@@ -7600,7 +7608,7 @@
       "from": "port",
       "name": "widget_map"
     },
-    "index": 1037,
+    "index": 1038,
     "type": "hit"
   },
   {
@@ -7608,7 +7616,7 @@
       "from": "port",
       "name": "player"
     },
-    "index": 1038,
+    "index": 1039,
     "type": "hit"
   },
   {
@@ -7616,21 +7624,13 @@
       "from": "trigger",
       "name": "location_loiqe-satellite"
     },
-    "index": 1039,
+    "index": 1040,
     "type": "hit"
   },
   {
     "data": "satellite",
-    "index": 1040,
-    "type": "pilotAligned"
-  },
-  {
-    "data": {
-      "from": "port",
-      "name": "widget_map"
-    },
     "index": 1041,
-    "type": "hit"
+    "type": "pilotAligned"
   },
   {
     "data": {
@@ -7642,8 +7642,8 @@
   },
   {
     "data": {
-      "from": "trigger",
-      "name": "thruster_action"
+      "from": "port",
+      "name": "widget_map"
     },
     "index": 1043,
     "type": "hit"
@@ -7651,7 +7651,7 @@
   {
     "data": {
       "from": "trigger",
-      "name": "thruster_accelerate"
+      "name": "thruster_action"
     },
     "index": 1044,
     "type": "hit"
@@ -7673,8 +7673,16 @@
     "type": "hit"
   },
   {
-    "data": "satellite",
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
     "index": 1047,
+    "type": "hit"
+  },
+  {
+    "data": "satellite",
+    "index": 1048,
     "type": "docked"
   },
   {
@@ -7682,7 +7690,7 @@
       "from": "port",
       "name": "widget_map"
     },
-    "index": 1048,
+    "index": 1049,
     "type": "hit"
   },
   {
@@ -7690,7 +7698,7 @@
       "from": "port",
       "name": "player"
     },
-    "index": 1049,
+    "index": 1050,
     "type": "hit"
   },
   {
@@ -7698,21 +7706,13 @@
       "from": "trigger",
       "name": "location_valen-void"
     },
-    "index": 1050,
+    "index": 1051,
     "type": "hit"
   },
   {
     "data": "void",
-    "index": 1051,
-    "type": "pilotAligned"
-  },
-  {
-    "data": {
-      "from": "port",
-      "name": "widget_map"
-    },
     "index": 1052,
-    "type": "hit"
+    "type": "pilotAligned"
   },
   {
     "data": {
@@ -7724,8 +7724,8 @@
   },
   {
     "data": {
-      "from": "trigger",
-      "name": "thruster_action"
+      "from": "port",
+      "name": "widget_map"
     },
     "index": 1054,
     "type": "hit"
@@ -7733,7 +7733,7 @@
   {
     "data": {
       "from": "trigger",
-      "name": "thruster_accelerate"
+      "name": "thruster_action"
     },
     "index": 1055,
     "type": "hit"
@@ -7755,8 +7755,16 @@
     "type": "hit"
   },
   {
-    "data": "void",
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
     "index": 1058,
+    "type": "hit"
+  },
+  {
+    "data": "void",
+    "index": 1059,
     "type": "docked"
   },
   {
@@ -7765,7 +7773,7 @@
       "from": "port",
       "numberlessName": "console_line_#"
     },
-    "index": 1059,
+    "index": 1060,
     "type": "hit"
   },
   {
@@ -7773,12 +7781,12 @@
       "from": "port",
       "name": "valen-void_want"
     },
-    "index": 1060,
+    "index": 1061,
     "type": "hit"
   },
   {
     "data": "valen-void_want",
-    "index": 1061,
+    "index": 1062,
     "type": "upload"
   },
   {
@@ -7786,7 +7794,7 @@
       "from": "port",
       "name": "valen-void_give"
     },
-    "index": 1062,
+    "index": 1063,
     "type": "hit"
   },
   {
@@ -7794,12 +7802,12 @@
       "from": "port",
       "name": "mainpanel_cargo"
     },
-    "index": 1063,
+    "index": 1064,
     "type": "hit"
   },
   {
     "data": "cargo",
-    "index": 1064,
+    "index": 1065,
     "type": "upload"
   },
   {
@@ -7807,7 +7815,7 @@
       "from": "port",
       "name": "widget_map"
     },
-    "index": 1065,
+    "index": 1066,
     "type": "hit"
   },
   {
@@ -7815,7 +7823,7 @@
       "from": "port",
       "name": "player"
     },
-    "index": 1066,
+    "index": 1067,
     "type": "hit"
   },
   {
@@ -7823,21 +7831,13 @@
       "from": "trigger",
       "name": "location_valen-Valen"
     },
-    "index": 1067,
+    "index": 1068,
     "type": "hit"
   },
   {
     "data": "Valen",
-    "index": 1068,
-    "type": "pilotAligned"
-  },
-  {
-    "data": {
-      "from": "port",
-      "name": "widget_map"
-    },
     "index": 1069,
-    "type": "hit"
+    "type": "pilotAligned"
   },
   {
     "data": {
@@ -7849,8 +7849,8 @@
   },
   {
     "data": {
-      "from": "trigger",
-      "name": "thruster_action"
+      "from": "port",
+      "name": "widget_map"
     },
     "index": 1071,
     "type": "hit"
@@ -7858,7 +7858,7 @@
   {
     "data": {
       "from": "trigger",
-      "name": "thruster_accelerate"
+      "name": "thruster_action"
     },
     "index": 1072,
     "type": "hit"
@@ -7880,8 +7880,16 @@
     "type": "hit"
   },
   {
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 1074,
+    "type": "hit"
+  },
+  {
     "data": "Valen",
-    "index": 1075,
+    "index": 1076,
     "type": "docked"
   },
   {
@@ -7890,7 +7898,7 @@
       "from": "port",
       "numberlessName": "console_line_#"
     },
-    "index": 1076,
+    "index": 1077,
     "type": "hit"
   },
   {
@@ -7898,7 +7906,7 @@
       "from": "port",
       "name": "valen-Valen"
     },
-    "index": 1077,
+    "index": 1078,
     "type": "hit"
   },
   {
@@ -7906,12 +7914,12 @@
       "from": "trigger",
       "name": "button_valen-Valen_install"
     },
-    "index": 1078,
+    "index": 1079,
     "type": "hit"
   },
   {
     "data": "Valen",
-    "index": 1079,
+    "index": 1080,
     "type": "pilotAligned"
   },
   {
@@ -7919,7 +7927,7 @@
       "from": "port",
       "name": "widget_map"
     },
-    "index": 1080,
+    "index": 1081,
     "type": "hit"
   },
   {
@@ -7927,7 +7935,7 @@
       "from": "port",
       "name": "player"
     },
-    "index": 1081,
+    "index": 1082,
     "type": "hit"
   },
   {
@@ -7935,21 +7943,13 @@
       "from": "trigger",
       "name": "location_senni-bog"
     },
-    "index": 1082,
+    "index": 1083,
     "type": "hit"
   },
   {
     "data": "bog",
-    "index": 1083,
-    "type": "pilotAligned"
-  },
-  {
-    "data": {
-      "from": "port",
-      "name": "widget_map"
-    },
     "index": 1084,
-    "type": "hit"
+    "type": "pilotAligned"
   },
   {
     "data": {
@@ -7961,8 +7961,8 @@
   },
   {
     "data": {
-      "from": "trigger",
-      "name": "thruster_action"
+      "from": "port",
+      "name": "widget_map"
     },
     "index": 1086,
     "type": "hit"
@@ -7970,7 +7970,7 @@
   {
     "data": {
       "from": "trigger",
-      "name": "thruster_accelerate"
+      "name": "thruster_action"
     },
     "index": 1087,
     "type": "hit"
@@ -7992,8 +7992,16 @@
     "type": "hit"
   },
   {
-    "data": "bog",
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
     "index": 1090,
+    "type": "hit"
+  },
+  {
+    "data": "bog",
+    "index": 1091,
     "type": "docked"
   },
   {
@@ -8002,7 +8010,7 @@
       "from": "port",
       "numberlessName": "console_line_#"
     },
-    "index": 1091,
+    "index": 1092,
     "type": "hit"
   },
   {
@@ -8010,12 +8018,12 @@
       "from": "port",
       "name": "senni-bog_want"
     },
-    "index": 1092,
+    "index": 1093,
     "type": "hit"
   },
   {
     "data": "senni-bog_want",
-    "index": 1093,
+    "index": 1094,
     "type": "upload"
   },
   {
@@ -8023,7 +8031,7 @@
       "from": "port",
       "name": "senni-bog_give"
     },
-    "index": 1094,
+    "index": 1095,
     "type": "hit"
   },
   {
@@ -8031,12 +8039,12 @@
       "from": "port",
       "name": "mainpanel_cargo"
     },
-    "index": 1095,
+    "index": 1096,
     "type": "hit"
   },
   {
     "data": "cargo",
-    "index": 1096,
+    "index": 1097,
     "type": "upload"
   },
   {
@@ -8044,26 +8052,18 @@
       "from": "trigger",
       "name": "location_senni-Senni"
     },
-    "index": 1097,
+    "index": 1098,
     "type": "hit"
   },
   {
     "data": "Senni",
-    "index": 1098,
+    "index": 1099,
     "type": "pilotAligned"
   },
   {
     "data": {
       "from": "trigger",
       "name": "thruster_action"
-    },
-    "index": 1099,
-    "type": "hit"
-  },
-  {
-    "data": {
-      "from": "trigger",
-      "name": "thruster_accelerate"
     },
     "index": 1100,
     "type": "hit"
@@ -8085,8 +8085,16 @@
     "type": "hit"
   },
   {
-    "data": "Senni",
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
     "index": 1103,
+    "type": "hit"
+  },
+  {
+    "data": "Senni",
+    "index": 1104,
     "type": "docked"
   },
   {
@@ -8095,7 +8103,7 @@
       "from": "port",
       "numberlessName": "console_line_#"
     },
-    "index": 1104,
+    "index": 1105,
     "type": "hit"
   },
   {
@@ -8103,7 +8111,7 @@
       "from": "port",
       "name": "senni-Senni"
     },
-    "index": 1105,
+    "index": 1106,
     "type": "hit"
   },
   {
@@ -8111,12 +8119,12 @@
       "from": "trigger",
       "name": "button_senni-Senni_install"
     },
-    "index": 1106,
+    "index": 1107,
     "type": "hit"
   },
   {
     "data": "Senni",
-    "index": 1107,
+    "index": 1108,
     "type": "pilotAligned"
   },
   {
@@ -8124,26 +8132,18 @@
       "from": "trigger",
       "name": "location_senni-cargo"
     },
-    "index": 1108,
+    "index": 1109,
     "type": "hit"
   },
   {
     "data": "cargo",
-    "index": 1109,
+    "index": 1110,
     "type": "pilotAligned"
   },
   {
     "data": {
       "from": "trigger",
       "name": "thruster_action"
-    },
-    "index": 1110,
-    "type": "hit"
-  },
-  {
-    "data": {
-      "from": "trigger",
-      "name": "thruster_accelerate"
     },
     "index": 1111,
     "type": "hit"
@@ -8165,8 +8165,16 @@
     "type": "hit"
   },
   {
-    "data": "cargo",
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
     "index": 1114,
+    "type": "hit"
+  },
+  {
+    "data": "cargo",
+    "index": 1115,
     "type": "docked"
   },
   {
@@ -8175,7 +8183,7 @@
       "from": "port",
       "numberlessName": "battery_slot_cell#"
     },
-    "index": 1115,
+    "index": 1116,
     "type": "hit"
   },
   {
@@ -8183,7 +8191,7 @@
       "from": "port",
       "name": "battery_slot_radio"
     },
-    "index": 1116,
+    "index": 1117,
     "type": "hit"
   },
   {
@@ -8192,7 +8200,7 @@
       "from": "port",
       "numberlessName": "console_line_#"
     },
-    "index": 1117,
+    "index": 1118,
     "type": "hit"
   },
   {
@@ -8200,12 +8208,12 @@
       "from": "port",
       "name": "widget_radio"
     },
-    "index": 1118,
+    "index": 1119,
     "type": "hit"
   },
   {
     "data": "widget_radio",
-    "index": 1119,
+    "index": 1120,
     "type": "upload"
   },
   {
@@ -8213,7 +8221,7 @@
       "from": "port",
       "name": "widget_map"
     },
-    "index": 1120,
+    "index": 1121,
     "type": "hit"
   },
   {
@@ -8221,7 +8229,7 @@
       "from": "port",
       "name": "player"
     },
-    "index": 1121,
+    "index": 1122,
     "type": "hit"
   },
   {
@@ -8229,21 +8237,13 @@
       "from": "trigger",
       "name": "location_usul-annex"
     },
-    "index": 1122,
+    "index": 1123,
     "type": "hit"
   },
   {
     "data": "annex",
-    "index": 1123,
-    "type": "pilotAligned"
-  },
-  {
-    "data": {
-      "from": "port",
-      "name": "widget_map"
-    },
     "index": 1124,
-    "type": "hit"
+    "type": "pilotAligned"
   },
   {
     "data": {
@@ -8255,8 +8255,8 @@
   },
   {
     "data": {
-      "from": "trigger",
-      "name": "thruster_action"
+      "from": "port",
+      "name": "widget_map"
     },
     "index": 1126,
     "type": "hit"
@@ -8264,7 +8264,7 @@
   {
     "data": {
       "from": "trigger",
-      "name": "thruster_accelerate"
+      "name": "thruster_action"
     },
     "index": 1127,
     "type": "hit"
@@ -8286,8 +8286,16 @@
     "type": "hit"
   },
   {
-    "data": "annex",
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
     "index": 1130,
+    "type": "hit"
+  },
+  {
+    "data": "annex",
+    "index": 1131,
     "type": "docked"
   },
   {
@@ -8296,7 +8304,7 @@
       "from": "port",
       "numberlessName": "battery_slot_cell#"
     },
-    "index": 1131,
+    "index": 1132,
     "type": "hit"
   },
   {
@@ -8304,7 +8312,7 @@
       "from": "port",
       "name": "battery_slot_oxygen"
     },
-    "index": 1132,
+    "index": 1133,
     "type": "hit"
   },
   {
@@ -8312,26 +8320,18 @@
       "from": "trigger",
       "name": "location_usul-Usul"
     },
-    "index": 1133,
+    "index": 1134,
     "type": "hit"
   },
   {
     "data": "Usul",
-    "index": 1134,
+    "index": 1135,
     "type": "pilotAligned"
   },
   {
     "data": {
       "from": "trigger",
       "name": "thruster_action"
-    },
-    "index": 1135,
-    "type": "hit"
-  },
-  {
-    "data": {
-      "from": "trigger",
-      "name": "thruster_accelerate"
     },
     "index": 1136,
     "type": "hit"
@@ -8353,8 +8353,16 @@
     "type": "hit"
   },
   {
-    "data": "Usul",
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
     "index": 1139,
+    "type": "hit"
+  },
+  {
+    "data": "Usul",
+    "index": 1140,
     "type": "docked"
   },
   {
@@ -8363,7 +8371,7 @@
       "from": "port",
       "numberlessName": "console_line_#"
     },
-    "index": 1140,
+    "index": 1141,
     "type": "hit"
   },
   {
@@ -8371,7 +8379,7 @@
       "from": "port",
       "name": "usul-Usul"
     },
-    "index": 1141,
+    "index": 1142,
     "type": "hit"
   },
   {
@@ -8379,18 +8387,18 @@
       "from": "trigger",
       "name": "button_usul-Usul_install"
     },
-    "index": 1142,
+    "index": 1143,
     "type": "hit"
   },
   {
     "data": 18,
-    "index": 1143,
+    "index": 1144,
     "skip": true,
     "type": "mission"
   },
   {
     "data": "Usul",
-    "index": 1144,
+    "index": 1145,
     "type": "pilotAligned"
   },
   {
@@ -8398,7 +8406,7 @@
       "from": "port",
       "name": "widget_map"
     },
-    "index": 1145,
+    "index": 1146,
     "type": "hit"
   },
   {
@@ -8406,12 +8414,12 @@
       "from": "port",
       "name": "mainpanel_cargo"
     },
-    "index": 1146,
+    "index": 1147,
     "type": "hit"
   },
   {
     "data": "cargo",
-    "index": 1147,
+    "index": 1148,
     "type": "upload"
   },
   {
@@ -8420,7 +8428,7 @@
       "from": "port",
       "numberlessName": "console_line_#"
     },
-    "index": 1148,
+    "index": 1149,
     "type": "hit"
   },
   {
@@ -8428,12 +8436,12 @@
       "from": "port",
       "name": "widget_map"
     },
-    "index": 1149,
+    "index": 1150,
     "type": "hit"
   },
   {
     "data": "widget_map",
-    "index": 1150,
+    "index": 1151,
     "type": "upload"
   },
   {
@@ -8441,7 +8449,7 @@
       "from": "port",
       "name": "widget_map"
     },
-    "index": 1151,
+    "index": 1152,
     "type": "hit"
   },
   {
@@ -8449,21 +8457,13 @@
       "from": "port",
       "name": "player"
     },
-    "index": 1152,
+    "index": 1153,
     "type": "hit"
   },
   {
     "data": {
       "from": "trigger",
       "name": "location_usul-transit"
-    },
-    "index": 1153,
-    "type": "hit"
-  },
-  {
-    "data": {
-      "from": "port",
-      "name": "widget_map"
     },
     "index": 1154,
     "type": "hit"
@@ -8478,8 +8478,8 @@
   },
   {
     "data": {
-      "from": "trigger",
-      "name": "thruster_action"
+      "from": "port",
+      "name": "widget_map"
     },
     "index": 1156,
     "type": "hit"
@@ -8487,7 +8487,7 @@
   {
     "data": {
       "from": "trigger",
-      "name": "thruster_accelerate"
+      "name": "thruster_action"
     },
     "index": 1157,
     "type": "hit"
@@ -8509,8 +8509,16 @@
     "type": "hit"
   },
   {
-    "data": "transit",
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
     "index": 1160,
+    "type": "hit"
+  },
+  {
+    "data": "transit",
+    "index": 1161,
     "type": "docked"
   },
   {
@@ -8518,7 +8526,7 @@
       "from": "port",
       "name": "widget_map"
     },
-    "index": 1161,
+    "index": 1162,
     "type": "hit"
   },
   {
@@ -8526,12 +8534,12 @@
       "from": "port",
       "name": "mainpanel_cargo"
     },
-    "index": 1162,
+    "index": 1163,
     "type": "hit"
   },
   {
     "data": "cargo",
-    "index": 1163,
+    "index": 1164,
     "type": "upload"
   },
   {
@@ -8540,7 +8548,7 @@
       "from": "port",
       "numberlessName": "console_line_#"
     },
-    "index": 1164,
+    "index": 1165,
     "type": "hit"
   },
   {
@@ -8548,12 +8556,12 @@
       "from": "port",
       "name": "widget_map"
     },
-    "index": 1165,
+    "index": 1166,
     "type": "hit"
   },
   {
     "data": "widget_map",
-    "index": 1166,
+    "index": 1167,
     "type": "upload"
   },
   {
@@ -8561,7 +8569,7 @@
       "from": "trigger",
       "name": "location_close-close"
     },
-    "index": 1167,
+    "index": 1168,
     "type": "hit"
   },
   {
@@ -8569,7 +8577,7 @@
       "from": "trigger",
       "name": "thruster_action"
     },
-    "index": 1168,
+    "index": 1169,
     "type": "hit"
   },
   {
@@ -8577,12 +8585,12 @@
       "from": "trigger",
       "name": "thruster_accelerate"
     },
-    "index": 1169,
+    "index": 1170,
     "type": "hit"
   },
   {
     "data": 19,
-    "index": 1170,
+    "index": 1171,
     "skip": true,
     "type": "mission"
   }

--- a/verreciel_js/media/walkthrough.json
+++ b/verreciel_js/media/walkthrough.json
@@ -1,2914 +1,8589 @@
 [
-  { "skip": true, "type": "mission", "data": 0 },
-  { "skip": true, "type": "playerUnlock", "data": 0 },
   {
-    "type": "hit",
-    "data": {
-      "from": "port",
-      "numberlessName": "battery_slot_cell#",
-      "event": "battery-1"
-    }
-  },
-  {
-    "type": "hit",
-    "data": { "from": "port", "name": "battery_slot_thruster" }
+    "data": 0,
+    "index": 0,
+    "skip": true,
+    "type": "mission"
   },
-  { "type": "playerUnlock", "data": -45 },
-  { "type": "hit", "data": { "from": "trigger", "name": "thruster_action" } },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": 0,
+    "index": 1,
+    "skip": true,
+    "type": "playerUnlock"
   },
-  { "type": "playerUnlock", "data": -225 },
-  { "type": "hit", "data": { "from": "port", "name": "loiqe-Harvest_alta" } },
-  { "type": "hit", "data": { "from": "port", "name": "mainpanel_cargo" } },
-  { "type": "playerUnlock", "data": -270 },
-  { "type": "hit", "data": { "from": "port", "name": "mainpanel_cargo" } },
-  { "type": "hit", "data": { "from": "port", "name": "mainpanel_console" } },
-  { "type": "hit", "data": { "from": "trigger", "name": "thruster_action" } },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
-  },
-  { "skip": true, "type": "mission", "data": 0 },
-  { "type": "docked", "data": "City" },
-  {
-    "type": "hit",
     "data": {
+      "event": "battery-1",
       "from": "port",
-      "numberlessName": "console_line_#",
-      "event": "currency-1"
-    }
+      "numberlessName": "battery_slot_cell#"
+    },
+    "index": 2,
+    "type": "hit"
   },
-  { "type": "hit", "data": { "from": "port", "name": "loiqe-City_want" } },
-  { "type": "upload", "data": "loiqe-City_want" },
-  { "type": "hit", "data": { "from": "port", "name": "loiqe-City_give" } },
-  { "type": "hit", "data": { "from": "port", "name": "mainpanel_cargo" } },
-  { "skip": true, "type": "mission", "data": 1 },
-  { "type": "install", "data": "map" },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "location_loiqe-satellite" }
+    "data": {
+      "from": "port",
+      "name": "battery_slot_thruster"
+    },
+    "index": 3,
+    "type": "hit"
   },
-  { "type": "playerUnlock", "data": -135 },
-  { "type": "hit", "data": { "from": "port", "name": "mainpanel_radar" } },
-  { "type": "hit", "data": { "from": "port", "name": "mainpanel_pilot" } },
-  { "skip": true, "type": "mission", "data": 2 },
-  { "type": "pilotAligned", "data": "satellite" },
-  { "type": "hit", "data": { "from": "trigger", "name": "thruster_action" } },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": -45,
+    "index": 4,
+    "type": "playerUnlock"
   },
-  { "type": "docked", "data": "satellite" },
   {
-    "type": "hit",
-    "data": { "from": "port", "name": "loiqe-satellite_valen part 2" }
+    "data": {
+      "from": "trigger",
+      "name": "thruster_action"
+    },
+    "index": 5,
+    "type": "hit"
   },
-  { "type": "hit", "data": { "from": "port", "name": "mainpanel_cargo" } },
-  { "type": "upload", "data": "cargo" },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "location_loiqe-Horadric" }
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 6,
+    "type": "hit"
   },
-  { "type": "pilotAligned", "data": "Horadric" },
-  { "type": "hit", "data": { "from": "trigger", "name": "thruster_action" } },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": -225,
+    "index": 7,
+    "type": "playerUnlock"
   },
-  { "type": "docked", "data": "Horadric" },
   {
-    "type": "hit",
     "data": {
       "from": "port",
-      "numberlessName": "console_line_#",
-      "event": "valen-key-1"
-    }
+      "name": "loiqe-Harvest_alta"
+    },
+    "index": 8,
+    "type": "hit"
   },
   {
-    "type": "hit",
     "data": {
       "from": "port",
-      "numberlessName": "loiqe-Horadric_input_#",
-      "event": null
-    }
+      "name": "mainpanel_cargo"
+    },
+    "index": 9,
+    "type": "hit"
   },
-  { "type": "upload", "data": "loiqe-Horadric_input_#" },
   {
-    "type": "hit",
-    "data": {
-      "from": "port",
-      "numberlessName": "console_line_#",
-      "event": "valen-key-2"
-    }
+    "data": -270,
+    "index": 10,
+    "type": "playerUnlock"
   },
   {
-    "type": "hit",
     "data": {
       "from": "port",
-      "numberlessName": "loiqe-Horadric_input_#",
-      "event": null
-    }
+      "name": "mainpanel_cargo"
+    },
+    "index": 11,
+    "type": "hit"
   },
-  { "type": "combination", "data": "valen key" },
   {
-    "type": "hit",
-    "data": { "from": "port", "name": "loiqe-Horadric_output_1" }
+    "data": {
+      "from": "port",
+      "name": "mainpanel_console"
+    },
+    "index": 12,
+    "type": "hit"
   },
-  { "type": "hit", "data": { "from": "port", "name": "mainpanel_cargo" } },
-  { "skip": true, "type": "mission", "data": 3 },
-  { "type": "install", "data": "exploration" },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "location_loiqe-satellite" }
+    "data": {
+      "from": "trigger",
+      "name": "thruster_action"
+    },
+    "index": 13,
+    "type": "hit"
   },
-  { "type": "pilotAligned", "data": "satellite" },
-  { "type": "hit", "data": { "from": "trigger", "name": "thruster_action" } },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 14,
+    "type": "hit"
   },
-  { "type": "docked", "data": "satellite" },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "location_loiqe-portal" }
+    "data": 0,
+    "index": 15,
+    "skip": true,
+    "type": "mission"
   },
-  { "type": "pilotAligned", "data": "portal" },
-  { "type": "hit", "data": { "from": "trigger", "name": "thruster_action" } },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": "City",
+    "index": 16,
+    "type": "docked"
   },
-  { "type": "docked", "data": "portal" },
   {
-    "type": "hit",
     "data": {
+      "event": "currency-1",
       "from": "port",
-      "numberlessName": "console_line_#",
-      "event": "valen-key"
-    }
+      "numberlessName": "console_line_#"
+    },
+    "index": 17,
+    "type": "hit"
   },
-  { "type": "hit", "data": { "from": "port", "name": "mainpanel_mission" } },
   {
-    "type": "hit",
-    "data": { "from": "port", "name": "loiqe-portal_thruster" }
+    "data": {
+      "from": "port",
+      "name": "loiqe-City_want"
+    },
+    "index": 18,
+    "type": "hit"
   },
-  { "type": "hit", "data": { "from": "port", "name": "mainpanel_thruster" } },
-  { "type": "hit", "data": { "from": "port", "name": "mainpanel_radar" } },
-  { "type": "hit", "data": { "from": "port", "name": "mainpanel_radar" } },
-  { "type": "hit", "data": { "from": "port", "name": "loiqe-portal_pilot" } },
-  { "type": "hit", "data": { "from": "port", "name": "mainpanel_pilot" } },
-  { "type": "pilotAligned", "data": "portal" },
-  { "type": "hit", "data": { "from": "trigger", "name": "thruster_action" } },
-  { "type": "docked", "data": "portal" },
-  { "type": "hit", "data": { "from": "port", "name": "mainpanel_radar" } },
-  { "type": "hit", "data": { "from": "port", "name": "mainpanel_pilot" } },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "location_valen-Bank" }
+    "data": "loiqe-City_want",
+    "index": 19,
+    "type": "upload"
   },
-  { "type": "hit", "data": { "from": "trigger", "name": "thruster_action" } },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": {
+      "from": "port",
+      "name": "loiqe-City_give"
+    },
+    "index": 20,
+    "type": "hit"
   },
-  { "type": "docked", "data": "Bank" },
   {
-    "type": "hit",
     "data": {
       "from": "port",
-      "numberlessName": "valen-Bank_slot_#",
-      "event": "record1"
-    }
+      "name": "mainpanel_cargo"
+    },
+    "index": 21,
+    "type": "hit"
+  },
+  {
+    "data": 1,
+    "index": 22,
+    "skip": true,
+    "type": "mission"
+  },
+  {
+    "data": "map",
+    "index": 23,
+    "type": "install"
   },
-  { "type": "hit", "data": { "from": "port", "name": "mainpanel_cargo" } },
-  { "type": "upload", "data": "cargo" },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "location_valen-cargo" }
+    "data": {
+      "from": "trigger",
+      "name": "location_loiqe-satellite"
+    },
+    "index": 24,
+    "type": "hit"
   },
-  { "type": "hit", "data": { "from": "trigger", "name": "thruster_action" } },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": -135,
+    "index": 25,
+    "type": "playerUnlock"
   },
-  { "type": "docked", "data": "cargo" },
-  { "type": "hit", "data": { "from": "port", "name": "valen-cargo_cell" } },
-  { "type": "hit", "data": { "from": "port", "name": "mainpanel_cargo" } },
-  { "type": "upload", "data": "cargo" },
   {
-    "type": "hit",
     "data": {
       "from": "port",
-      "numberlessName": "console_line_#",
-      "event": "battery-2"
-    }
+      "name": "mainpanel_radar"
+    },
+    "index": 26,
+    "type": "hit"
   },
   {
-    "type": "hit",
     "data": {
       "from": "port",
-      "numberlessName": "battery_slot_cell#",
-      "event": null
-    }
+      "name": "mainpanel_pilot"
+    },
+    "index": 27,
+    "type": "hit"
   },
-  { "type": "upload", "data": "battery_slot_cell#" },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "location_valen-harvest" }
+    "data": 2,
+    "index": 28,
+    "skip": true,
+    "type": "mission"
   },
-  { "type": "pilotAligned", "data": "harvest" },
-  { "type": "hit", "data": { "from": "trigger", "name": "thruster_action" } },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": "satellite",
+    "index": 29,
+    "type": "pilotAligned"
   },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": {
+      "from": "trigger",
+      "name": "thruster_action"
+    },
+    "index": 30,
+    "type": "hit"
   },
-  { "type": "docked", "data": "harvest" },
-  { "type": "hit", "data": { "from": "port", "name": "valen-harvest_ikov" } },
-  { "type": "hit", "data": { "from": "port", "name": "mainpanel_cargo" } },
-  { "type": "upload", "data": "cargo" },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "location_valen-station" }
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 31,
+    "type": "hit"
   },
-  { "type": "pilotAligned", "data": "station" },
-  { "type": "hit", "data": { "from": "trigger", "name": "thruster_action" } },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": "satellite",
+    "index": 32,
+    "type": "docked"
   },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": {
+      "from": "port",
+      "name": "loiqe-satellite_valen part 2"
+    },
+    "index": 33,
+    "type": "hit"
   },
-  { "type": "docked", "data": "station" },
   {
-    "type": "hit",
     "data": {
       "from": "port",
-      "numberlessName": "console_line_#",
-      "event": "currency-2"
-    }
+      "name": "mainpanel_cargo"
+    },
+    "index": 34,
+    "type": "hit"
   },
-  { "type": "hit", "data": { "from": "port", "name": "valen-station" } },
-  { "type": "upload", "data": "valen-station" },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "button_valen-station_install" }
+    "data": "cargo",
+    "index": 35,
+    "type": "upload"
   },
-  { "type": "install", "data": "journey" },
   {
-    "type": "hit",
     "data": {
-      "from": "port",
-      "numberlessName": "battery_slot_cell#",
-      "event": "battery-2"
-    }
+      "from": "trigger",
+      "name": "location_loiqe-Horadric"
+    },
+    "index": 36,
+    "type": "hit"
   },
-  { "type": "hit", "data": { "from": "port", "name": "battery_slot_radio" } },
   {
-    "type": "hit",
-    "data": {
-      "from": "port",
-      "numberlessName": "console_line_#",
-      "event": "record1"
-    }
+    "data": "Horadric",
+    "index": 37,
+    "type": "pilotAligned"
   },
-  { "type": "hit", "data": { "from": "port", "name": "widget_radio" } },
-  { "skip": true, "type": "mission", "data": 6 },
-  { "type": "upload", "data": "widget_radio" },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "location_valen-Bank" }
+    "data": {
+      "from": "trigger",
+      "name": "thruster_action"
+    },
+    "index": 38,
+    "type": "hit"
   },
-  { "type": "pilotAligned", "data": "Bank" },
-  { "type": "hit", "data": { "from": "trigger", "name": "thruster_action" } },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 39,
+    "type": "hit"
   },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": "Horadric",
+    "index": 40,
+    "type": "docked"
   },
-  { "type": "docked", "data": "Bank" },
   {
-    "type": "hit",
     "data": {
+      "event": "valen-key-1",
       "from": "port",
-      "numberlessName": "valen-Bank_slot_#",
-      "event": "waste"
-    }
+      "numberlessName": "console_line_#"
+    },
+    "index": 41,
+    "type": "hit"
   },
-  { "type": "hit", "data": { "from": "port", "name": "mainpanel_cargo" } },
-  { "type": "playerUnlock", "data": -315 },
   {
-    "type": "hit",
     "data": {
+      "event": null,
       "from": "port",
-      "numberlessName": "console_line_#",
-      "event": "waste"
-    }
+      "numberlessName": "loiqe-Horadric_input_#"
+    },
+    "index": 42,
+    "type": "hit"
+  },
+  {
+    "data": "loiqe-Horadric_input_#",
+    "index": 43,
+    "type": "upload"
   },
-  { "type": "hit", "data": { "from": "port", "name": "mainpanel_hatch" } },
-  { "type": "hit", "data": { "from": "trigger", "name": "hatch_jettison" } },
-  { "type": "install", "data": "missions" },
   {
-    "type": "hit",
     "data": {
+      "event": "valen-key-2",
       "from": "port",
-      "numberlessName": "valen-Bank_slot_#",
-      "event": "loiqe-key"
-    }
+      "numberlessName": "console_line_#"
+    },
+    "index": 44,
+    "type": "hit"
   },
-  { "type": "hit", "data": { "from": "port", "name": "mainpanel_cargo" } },
-  { "skip": true, "type": "mission", "data": 8 },
-  { "type": "upload", "data": "cargo" },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "location_valen-harvest" }
+    "data": {
+      "event": null,
+      "from": "port",
+      "numberlessName": "loiqe-Horadric_input_#"
+    },
+    "index": 45,
+    "type": "hit"
   },
-  { "type": "pilotAligned", "data": "harvest" },
-  { "type": "hit", "data": { "from": "trigger", "name": "thruster_action" } },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": "valen key",
+    "index": 46,
+    "type": "combination"
   },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": {
+      "from": "port",
+      "name": "loiqe-Horadric_output_1"
+    },
+    "index": 47,
+    "type": "hit"
   },
-  { "type": "docked", "data": "harvest" },
-  { "type": "hit", "data": { "from": "port", "name": "valen-harvest_ikov" } },
-  { "type": "hit", "data": { "from": "port", "name": "mainpanel_cargo" } },
-  { "type": "upload", "data": "cargo" },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "location_valen-Bank" }
+    "data": {
+      "from": "port",
+      "name": "mainpanel_cargo"
+    },
+    "index": 48,
+    "type": "hit"
   },
-  { "type": "pilotAligned", "data": "Bank" },
-  { "type": "hit", "data": { "from": "trigger", "name": "thruster_action" } },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": 3,
+    "index": 49,
+    "skip": true,
+    "type": "mission"
   },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": "exploration",
+    "index": 50,
+    "type": "install"
   },
-  { "type": "docked", "data": "Bank" },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "location_valen-portal" }
+    "data": {
+      "from": "trigger",
+      "name": "location_loiqe-satellite"
+    },
+    "index": 51,
+    "type": "hit"
   },
-  { "type": "pilotAligned", "data": "portal" },
-  { "type": "hit", "data": { "from": "trigger", "name": "thruster_action" } },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": "satellite",
+    "index": 52,
+    "type": "pilotAligned"
   },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": {
+      "from": "trigger",
+      "name": "thruster_action"
+    },
+    "index": 53,
+    "type": "hit"
   },
-  { "type": "docked", "data": "portal" },
   {
-    "type": "hit",
     "data": {
-      "from": "port",
-      "numberlessName": "console_line_#",
-      "event": "loiqe-key"
-    }
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 54,
+    "type": "hit"
   },
-  { "type": "hit", "data": { "from": "port", "name": "mainpanel_mission" } },
   {
-    "type": "hit",
-    "data": { "from": "port", "name": "valen-portal_thruster" }
+    "data": "satellite",
+    "index": 55,
+    "type": "docked"
   },
-  { "type": "hit", "data": { "from": "port", "name": "mainpanel_thruster" } },
-  { "type": "hit", "data": { "from": "port", "name": "mainpanel_radar" } },
-  { "type": "hit", "data": { "from": "port", "name": "mainpanel_radar" } },
-  { "type": "hit", "data": { "from": "port", "name": "valen-portal_pilot" } },
-  { "type": "hit", "data": { "from": "port", "name": "mainpanel_pilot" } },
-  { "type": "hit", "data": { "from": "trigger", "name": "thruster_action" } },
-  { "type": "docked", "data": "portal" },
-  { "type": "hit", "data": { "from": "port", "name": "mainpanel_radar" } },
-  { "type": "hit", "data": { "from": "port", "name": "mainpanel_pilot" } },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "location_loiqe-satellite" }
+    "data": {
+      "from": "trigger",
+      "name": "location_loiqe-portal"
+    },
+    "index": 56,
+    "type": "hit"
   },
-  { "type": "pilotAligned", "data": "satellite" },
-  { "type": "hit", "data": { "from": "trigger", "name": "thruster_action" } },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": "portal",
+    "index": 57,
+    "type": "pilotAligned"
   },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": {
+      "from": "trigger",
+      "name": "thruster_action"
+    },
+    "index": 58,
+    "type": "hit"
   },
-  { "type": "docked", "data": "satellite" },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "location_loiqe-City" }
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 59,
+    "type": "hit"
   },
-  { "type": "pilotAligned", "data": "City" },
-  { "type": "hit", "data": { "from": "trigger", "name": "thruster_action" } },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": "portal",
+    "index": 60,
+    "type": "docked"
   },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": {
+      "event": "valen-key",
+      "from": "port",
+      "numberlessName": "console_line_#"
+    },
+    "index": 61,
+    "type": "hit"
   },
-  { "type": "docked", "data": "City" },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "location_loiqe-Harvest" }
+    "data": {
+      "from": "port",
+      "name": "mainpanel_mission"
+    },
+    "index": 62,
+    "type": "hit"
   },
-  { "type": "pilotAligned", "data": "Harvest" },
-  { "type": "hit", "data": { "from": "trigger", "name": "thruster_action" } },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": {
+      "from": "port",
+      "name": "loiqe-portal_thruster"
+    },
+    "index": 63,
+    "type": "hit"
   },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": {
+      "from": "port",
+      "name": "mainpanel_thruster"
+    },
+    "index": 64,
+    "type": "hit"
   },
-  { "type": "docked", "data": "Harvest" },
-  { "type": "hit", "data": { "from": "port", "name": "loiqe-Harvest_alta" } },
-  { "type": "hit", "data": { "from": "port", "name": "mainpanel_cargo" } },
-  { "type": "upload", "data": "cargo" },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "location_loiqe-City" }
+    "data": {
+      "from": "port",
+      "name": "mainpanel_radar"
+    },
+    "index": 65,
+    "type": "hit"
   },
-  { "type": "pilotAligned", "data": "City" },
-  { "type": "hit", "data": { "from": "trigger", "name": "thruster_action" } },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": {
+      "from": "port",
+      "name": "mainpanel_radar"
+    },
+    "index": 66,
+    "type": "hit"
   },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": {
+      "from": "port",
+      "name": "loiqe-portal_pilot"
+    },
+    "index": 67,
+    "type": "hit"
   },
-  { "type": "docked", "data": "City" },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "location_loiqe-satellite" }
+    "data": {
+      "from": "port",
+      "name": "mainpanel_pilot"
+    },
+    "index": 68,
+    "type": "hit"
   },
-  { "type": "pilotAligned", "data": "satellite" },
-  { "type": "hit", "data": { "from": "trigger", "name": "thruster_action" } },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": "portal",
+    "index": 69,
+    "type": "pilotAligned"
   },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": {
+      "from": "trigger",
+      "name": "thruster_action"
+    },
+    "index": 70,
+    "type": "hit"
   },
-  { "type": "docked", "data": "satellite" },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "location_loiqe-Horadric" }
+    "data": "portal",
+    "index": 71,
+    "type": "docked"
   },
-  { "type": "pilotAligned", "data": "Horadric" },
-  { "type": "hit", "data": { "from": "trigger", "name": "thruster_action" } },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": {
+      "from": "port",
+      "name": "mainpanel_radar"
+    },
+    "index": 72,
+    "type": "hit"
   },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": {
+      "from": "port",
+      "name": "mainpanel_pilot"
+    },
+    "index": 73,
+    "type": "hit"
   },
-  { "type": "docked", "data": "Horadric" },
   {
-    "type": "hit",
     "data": {
-      "from": "port",
-      "numberlessName": "console_line_#",
-      "event": "currency-1"
-    }
+      "from": "trigger",
+      "name": "location_valen-Bank"
+    },
+    "index": 74,
+    "type": "hit"
   },
   {
-    "type": "hit",
     "data": {
-      "from": "port",
-      "numberlessName": "loiqe-Horadric_input_#",
-      "event": null
-    }
+      "from": "trigger",
+      "name": "thruster_action"
+    },
+    "index": 75,
+    "type": "hit"
   },
-  { "type": "upload", "data": "loiqe-Horadric_input_#" },
   {
-    "type": "hit",
     "data": {
-      "from": "port",
-      "numberlessName": "console_line_#",
-      "event": "currency-2"
-    }
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 76,
+    "type": "hit"
   },
   {
-    "type": "hit",
+    "data": "Bank",
+    "index": 77,
+    "type": "docked"
+  },
+  {
     "data": {
+      "event": "record1",
       "from": "port",
-      "numberlessName": "loiqe-Horadric_input_#",
-      "event": null
-    }
+      "numberlessName": "valen-Bank_slot_#"
+    },
+    "index": 78,
+    "type": "hit"
   },
-  { "type": "combination", "data": "altiov" },
   {
-    "type": "hit",
-    "data": { "from": "port", "name": "loiqe-Horadric_output_1" }
+    "data": {
+      "from": "port",
+      "name": "mainpanel_cargo"
+    },
+    "index": 79,
+    "type": "hit"
   },
-  { "type": "hit", "data": { "from": "port", "name": "mainpanel_cargo" } },
-  { "type": "upload", "data": "cargo" },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "location_loiqe-satellite" }
+    "data": "cargo",
+    "index": 80,
+    "type": "upload"
   },
-  { "type": "pilotAligned", "data": "satellite" },
-  { "type": "hit", "data": { "from": "trigger", "name": "thruster_action" } },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": {
+      "from": "trigger",
+      "name": "location_valen-cargo"
+    },
+    "index": 81,
+    "type": "hit"
   },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": {
+      "from": "trigger",
+      "name": "thruster_action"
+    },
+    "index": 82,
+    "type": "hit"
   },
-  { "type": "docked", "data": "satellite" },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "location_loiqe-portal" }
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 83,
+    "type": "hit"
   },
-  { "type": "pilotAligned", "data": "portal" },
-  { "type": "hit", "data": { "from": "trigger", "name": "thruster_action" } },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": "cargo",
+    "index": 84,
+    "type": "docked"
   },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": {
+      "from": "port",
+      "name": "valen-cargo_cell"
+    },
+    "index": 85,
+    "type": "hit"
   },
-  { "type": "docked", "data": "portal" },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "location_loiqe-port" }
+    "data": {
+      "from": "port",
+      "name": "mainpanel_cargo"
+    },
+    "index": 86,
+    "type": "hit"
   },
-  { "type": "pilotAligned", "data": "port" },
-  { "type": "hit", "data": { "from": "trigger", "name": "thruster_action" } },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": "cargo",
+    "index": 87,
+    "type": "upload"
   },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": {
+      "event": "battery-2",
+      "from": "port",
+      "numberlessName": "console_line_#"
+    },
+    "index": 88,
+    "type": "hit"
   },
-  { "type": "docked", "data": "port" },
   {
-    "type": "hit",
     "data": {
+      "event": null,
       "from": "port",
-      "numberlessName": "console_line_#",
-      "event": "currency-4"
-    }
+      "numberlessName": "battery_slot_cell#"
+    },
+    "index": 89,
+    "type": "hit"
   },
-  { "type": "hit", "data": { "from": "port", "name": "loiqe-port_want" } },
-  { "type": "upload", "data": "loiqe-port_want" },
-  { "type": "hit", "data": { "from": "port", "name": "loiqe-port_give" } },
-  { "type": "hit", "data": { "from": "port", "name": "mainpanel_cargo" } },
-  { "type": "upload", "data": "cargo" },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "location_loiqe-portal" }
+    "data": "battery_slot_cell#",
+    "index": 90,
+    "type": "upload"
   },
-  { "type": "pilotAligned", "data": "portal" },
-  { "type": "hit", "data": { "from": "trigger", "name": "thruster_action" } },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": {
+      "from": "trigger",
+      "name": "location_valen-harvest"
+    },
+    "index": 91,
+    "type": "hit"
   },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": "harvest",
+    "index": 92,
+    "type": "pilotAligned"
   },
-  { "type": "docked", "data": "portal" },
   {
-    "type": "hit",
     "data": {
-      "from": "port",
-      "numberlessName": "console_line_#",
-      "event": "senni-key"
-    }
+      "from": "trigger",
+      "name": "thruster_action"
+    },
+    "index": 93,
+    "type": "hit"
   },
-  { "type": "hit", "data": { "from": "port", "name": "mainpanel_mission" } },
   {
-    "type": "hit",
-    "data": { "from": "port", "name": "loiqe-portal_thruster" }
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 94,
+    "type": "hit"
   },
-  { "type": "hit", "data": { "from": "port", "name": "mainpanel_thruster" } },
-  { "type": "hit", "data": { "from": "port", "name": "mainpanel_radar" } },
-  { "type": "hit", "data": { "from": "port", "name": "mainpanel_radar" } },
-  { "type": "hit", "data": { "from": "port", "name": "loiqe-portal_pilot" } },
-  { "type": "hit", "data": { "from": "port", "name": "mainpanel_pilot" } },
-  { "type": "pilotAligned", "data": "portal" },
-  { "type": "hit", "data": { "from": "trigger", "name": "thruster_action" } },
-  { "type": "docked", "data": "portal" },
-  { "type": "hit", "data": { "from": "port", "name": "mainpanel_radar" } },
-  { "type": "hit", "data": { "from": "port", "name": "mainpanel_pilot" } },
-  { "type": "hit", "data": { "from": "trigger", "name": "thruster_action" } },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "location_senni-cargo" }
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 95,
+    "type": "hit"
   },
-  { "type": "pilotAligned", "data": "cargo" },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": "harvest",
+    "index": 96,
+    "type": "docked"
   },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": {
+      "from": "port",
+      "name": "valen-harvest_ikov"
+    },
+    "index": 97,
+    "type": "hit"
   },
-  { "type": "docked", "data": "cargo" },
-  { "type": "hit", "data": { "from": "port", "name": "senni-cargo_Fog Map" } },
-  { "type": "hit", "data": { "from": "port", "name": "mainpanel_cargo" } },
-  { "type": "upload", "data": "cargo" },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "location_senni-harvest" }
+    "data": {
+      "from": "port",
+      "name": "mainpanel_cargo"
+    },
+    "index": 98,
+    "type": "hit"
   },
-  { "type": "pilotAligned", "data": "harvest" },
-  { "type": "hit", "data": { "from": "trigger", "name": "thruster_action" } },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": "cargo",
+    "index": 99,
+    "type": "upload"
   },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": {
+      "from": "trigger",
+      "name": "location_valen-station"
+    },
+    "index": 100,
+    "type": "hit"
   },
-  { "type": "docked", "data": "harvest" },
-  { "type": "hit", "data": { "from": "port", "name": "senni-harvest_eral" } },
-  { "type": "hit", "data": { "from": "port", "name": "mainpanel_cargo" } },
-  { "type": "upload", "data": "cargo" },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "location_senni-station" }
+    "data": "station",
+    "index": 101,
+    "type": "pilotAligned"
   },
-  { "type": "pilotAligned", "data": "station" },
-  { "type": "hit", "data": { "from": "trigger", "name": "thruster_action" } },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": {
+      "from": "trigger",
+      "name": "thruster_action"
+    },
+    "index": 102,
+    "type": "hit"
   },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 103,
+    "type": "hit"
   },
-  { "type": "docked", "data": "station" },
   {
-    "type": "hit",
     "data": {
-      "from": "port",
-      "numberlessName": "console_line_#",
-      "event": "currency-3"
-    }
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 104,
+    "type": "hit"
   },
-  { "type": "hit", "data": { "from": "port", "name": "senni-station" } },
-  { "type": "upload", "data": "senni-station" },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "button_senni-station_install" }
+    "data": "station",
+    "index": 105,
+    "type": "docked"
   },
-  { "type": "playerUnlock", "data": -90 },
   {
-    "type": "hit",
     "data": {
+      "event": "currency-2",
       "from": "port",
-      "numberlessName": "battery_slot_cell#",
-      "event": "battery-2"
-    }
+      "numberlessName": "console_line_#"
+    },
+    "index": 106,
+    "type": "hit"
   },
-  { "type": "hit", "data": { "from": "port", "name": "battery_slot_cloak" } },
   {
-    "type": "hit",
     "data": {
       "from": "port",
-      "numberlessName": "console_line_#",
-      "event": "map-1"
-    }
+      "name": "valen-station"
+    },
+    "index": 107,
+    "type": "hit"
   },
-  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
-  { "type": "upload", "data": "widget_map" },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "location_senni-fog" }
+    "data": "valen-station",
+    "index": 108,
+    "type": "upload"
   },
-  { "type": "hit", "data": { "from": "trigger", "name": "thruster_action" } },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": {
+      "from": "trigger",
+      "name": "button_valen-station_install"
+    },
+    "index": 109,
+    "type": "hit"
   },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": "journey",
+    "index": 110,
+    "type": "install"
   },
-  { "type": "docked", "data": "fog" },
-  { "type": "hit", "data": { "from": "port", "name": "senni-fog_cell" } },
-  { "type": "hit", "data": { "from": "port", "name": "mainpanel_cargo" } },
-  { "type": "upload", "data": "cargo" },
   {
-    "type": "hit",
     "data": {
+      "event": "battery-2",
       "from": "port",
-      "numberlessName": "console_line_#",
-      "event": "battery-3"
-    }
+      "numberlessName": "battery_slot_cell#"
+    },
+    "index": 111,
+    "type": "hit"
   },
   {
-    "type": "hit",
     "data": {
       "from": "port",
-      "numberlessName": "battery_slot_cell#",
-      "event": null
-    }
-  },
-  { "skip": true, "type": "mission", "data": 12 },
-  { "type": "upload", "data": "battery_slot_cell#" },
-  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
-  { "type": "hit", "data": { "from": "port", "name": "player" } },
-  { "type": "mission", "data": 13 },
-  {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "location_valen-harvest" }
+      "name": "battery_slot_radio"
+    },
+    "index": 112,
+    "type": "hit"
   },
-  { "type": "pilotAligned", "data": "harvest" },
-  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
-  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
-  { "type": "hit", "data": { "from": "trigger", "name": "thruster_action" } },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": {
+      "event": "record1",
+      "from": "port",
+      "numberlessName": "console_line_#"
+    },
+    "index": 113,
+    "type": "hit"
   },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": {
+      "from": "port",
+      "name": "widget_radio"
+    },
+    "index": 114,
+    "type": "hit"
   },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": 6,
+    "index": 115,
+    "skip": true,
+    "type": "mission"
   },
-  { "type": "docked", "data": "harvest" },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "location_valen-station" }
+    "data": "widget_radio",
+    "index": 116,
+    "type": "upload"
   },
-  { "type": "hit", "data": { "from": "trigger", "name": "thruster_action" } },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": {
+      "from": "trigger",
+      "name": "location_valen-Bank"
+    },
+    "index": 117,
+    "type": "hit"
   },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": "Bank",
+    "index": 118,
+    "type": "pilotAligned"
   },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": {
+      "from": "trigger",
+      "name": "thruster_action"
+    },
+    "index": 119,
+    "type": "hit"
   },
-  { "type": "docked", "data": "station" },
-  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
-  { "type": "hit", "data": { "from": "port", "name": "player" } },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "location_valen-fog" }
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 120,
+    "type": "hit"
   },
-  { "type": "pilotAligned", "data": "fog" },
-  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
-  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
-  { "type": "hit", "data": { "from": "trigger", "name": "thruster_action" } },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 121,
+    "type": "hit"
   },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": "Bank",
+    "index": 122,
+    "type": "docked"
   },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": {
+      "event": "waste",
+      "from": "port",
+      "numberlessName": "valen-Bank_slot_#"
+    },
+    "index": 123,
+    "type": "hit"
   },
-  { "type": "docked", "data": "fog" },
   {
-    "type": "hit",
-    "data": { "from": "port", "name": "valen-fog_usul Part 1" }
+    "data": {
+      "from": "port",
+      "name": "mainpanel_cargo"
+    },
+    "index": 124,
+    "type": "hit"
   },
-  { "type": "hit", "data": { "from": "port", "name": "mainpanel_cargo" } },
-  { "type": "upload", "data": "cargo" },
-  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
-  { "type": "hit", "data": { "from": "port", "name": "player" } },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "location_loiqe-Horadric" }
+    "data": -315,
+    "index": 125,
+    "type": "playerUnlock"
   },
-  { "type": "pilotAligned", "data": "Horadric" },
-  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
-  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
-  { "type": "hit", "data": { "from": "trigger", "name": "thruster_action" } },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": {
+      "event": "waste",
+      "from": "port",
+      "numberlessName": "console_line_#"
+    },
+    "index": 126,
+    "type": "hit"
   },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": {
+      "from": "port",
+      "name": "mainpanel_hatch"
+    },
+    "index": 127,
+    "type": "hit"
   },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": {
+      "from": "trigger",
+      "name": "hatch_jettison"
+    },
+    "index": 128,
+    "type": "hit"
   },
-  { "type": "docked", "data": "Horadric" },
-  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
-  { "type": "hit", "data": { "from": "port", "name": "player" } },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "location_loiqe-portal" }
+    "data": "missions",
+    "index": 129,
+    "type": "install"
   },
-  { "type": "pilotAligned", "data": "portal" },
-  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
-  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
-  { "type": "hit", "data": { "from": "trigger", "name": "thruster_action" } },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": {
+      "event": "loiqe-key",
+      "from": "port",
+      "numberlessName": "valen-Bank_slot_#"
+    },
+    "index": 130,
+    "type": "hit"
   },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": {
+      "from": "port",
+      "name": "mainpanel_cargo"
+    },
+    "index": 131,
+    "type": "hit"
   },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": 8,
+    "index": 132,
+    "skip": true,
+    "type": "mission"
   },
-  { "type": "docked", "data": "portal" },
-  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
-  { "type": "hit", "data": { "from": "port", "name": "player" } },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "location_loiqe-fog" }
+    "data": "cargo",
+    "index": 133,
+    "type": "upload"
   },
-  { "type": "pilotAligned", "data": "fog" },
-  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
-  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
-  { "type": "hit", "data": { "from": "trigger", "name": "thruster_action" } },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": {
+      "from": "trigger",
+      "name": "location_valen-harvest"
+    },
+    "index": 134,
+    "type": "hit"
   },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": "harvest",
+    "index": 135,
+    "type": "pilotAligned"
   },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": {
+      "from": "trigger",
+      "name": "thruster_action"
+    },
+    "index": 136,
+    "type": "hit"
   },
-  { "type": "docked", "data": "fog" },
-  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
-  { "type": "hit", "data": { "from": "port", "name": "player" } },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "location_loiqe-portal" }
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 137,
+    "type": "hit"
   },
-  { "type": "pilotAligned", "data": "portal" },
-  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
-  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
-  { "type": "hit", "data": { "from": "trigger", "name": "thruster_action" } },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 138,
+    "type": "hit"
   },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": "currency-2",
+    "index": 139,
+    "type": "harvest"
   },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": {
+      "from": "port",
+      "name": "valen-harvest_ikov"
+    },
+    "index": 140,
+    "type": "hit"
   },
-  { "type": "docked", "data": "portal" },
   {
-    "type": "hit",
     "data": {
       "from": "port",
-      "numberlessName": "console_line_#",
-      "event": "senni-key"
-    }
+      "name": "mainpanel_cargo"
+    },
+    "index": 141,
+    "type": "hit"
   },
-  { "type": "hit", "data": { "from": "port", "name": "mainpanel_mission" } },
   {
-    "type": "hit",
-    "data": { "from": "port", "name": "loiqe-portal_thruster" }
+    "data": "cargo",
+    "index": 142,
+    "type": "upload"
   },
-  { "type": "hit", "data": { "from": "port", "name": "mainpanel_thruster" } },
-  { "type": "hit", "data": { "from": "port", "name": "mainpanel_radar" } },
-  { "type": "hit", "data": { "from": "port", "name": "mainpanel_radar" } },
-  { "type": "hit", "data": { "from": "port", "name": "loiqe-portal_pilot" } },
-  { "type": "hit", "data": { "from": "port", "name": "mainpanel_pilot" } },
-  { "type": "pilotAligned", "data": "portal" },
-  { "type": "hit", "data": { "from": "trigger", "name": "thruster_action" } },
-  { "type": "docked", "data": "portal" },
-  { "type": "hit", "data": { "from": "port", "name": "mainpanel_radar" } },
-  { "type": "hit", "data": { "from": "port", "name": "mainpanel_pilot" } },
-  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
-  { "type": "hit", "data": { "from": "port", "name": "player" } },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "location_senni-wreck" }
+    "data": {
+      "from": "trigger",
+      "name": "location_valen-Bank"
+    },
+    "index": 143,
+    "type": "hit"
   },
-  { "type": "pilotAligned", "data": "wreck" },
-  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
-  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
-  { "type": "hit", "data": { "from": "trigger", "name": "thruster_action" } },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": "Bank",
+    "index": 144,
+    "type": "pilotAligned"
   },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": {
+      "from": "trigger",
+      "name": "thruster_action"
+    },
+    "index": 145,
+    "type": "hit"
   },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 146,
+    "type": "hit"
   },
-  { "type": "docked", "data": "wreck" },
   {
-    "type": "hit",
     "data": {
-      "from": "port",
-      "numberlessName": "battery_slot_cell#",
-      "event": "battery-3"
-    }
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 147,
+    "type": "hit"
   },
-  { "type": "hit", "data": { "from": "port", "name": "battery_slot_radio" } },
-  { "type": "hit", "data": { "from": "port", "name": "widget_radio" } },
-  { "type": "hit", "data": { "from": "port", "name": "mainpanel_cargo" } },
-  { "type": "upload", "data": "cargo" },
-  { "type": "hit", "data": { "from": "port", "name": "senni-wreck_disk" } },
-  { "type": "hit", "data": { "from": "port", "name": "widget_radio" } },
-  { "type": "upload", "data": "widget_radio" },
-  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
-  { "type": "hit", "data": { "from": "port", "name": "player" } },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "location_senni-harvest" }
+    "data": "Bank",
+    "index": 148,
+    "type": "docked"
   },
-  { "type": "pilotAligned", "data": "harvest" },
-  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
-  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
-  { "type": "hit", "data": { "from": "trigger", "name": "thruster_action" } },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": {
+      "from": "trigger",
+      "name": "location_valen-portal"
+    },
+    "index": 149,
+    "type": "hit"
   },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": "portal",
+    "index": 150,
+    "type": "pilotAligned"
   },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": {
+      "from": "trigger",
+      "name": "thruster_action"
+    },
+    "index": 151,
+    "type": "hit"
   },
-  { "type": "docked", "data": "harvest" },
-  { "type": "hit", "data": { "from": "port", "name": "senni-harvest_eral" } },
-  { "type": "hit", "data": { "from": "port", "name": "mainpanel_cargo" } },
-  { "type": "upload", "data": "cargo" },
-  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
-  { "type": "hit", "data": { "from": "port", "name": "player" } },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "location_valen-Bank" }
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 152,
+    "type": "hit"
   },
-  { "type": "pilotAligned", "data": "Bank" },
-  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
-  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
-  { "type": "hit", "data": { "from": "trigger", "name": "thruster_action" } },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 153,
+    "type": "hit"
   },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": "portal",
+    "index": 154,
+    "type": "docked"
   },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": {
+      "event": "loiqe-key",
+      "from": "port",
+      "numberlessName": "console_line_#"
+    },
+    "index": 155,
+    "type": "hit"
   },
-  { "type": "docked", "data": "Bank" },
   {
-    "type": "hit",
     "data": {
       "from": "port",
-      "numberlessName": "console_line_#",
-      "event": "valen-key"
-    }
+      "name": "mainpanel_mission"
+    },
+    "index": 156,
+    "type": "hit"
   },
   {
-    "type": "hit",
     "data": {
       "from": "port",
-      "numberlessName": "valen-Bank_slot_#",
-      "event": null
-    }
+      "name": "valen-portal_thruster"
+    },
+    "index": 157,
+    "type": "hit"
   },
-  { "type": "upload", "data": "valen-Bank_slot_#" },
   {
-    "type": "hit",
     "data": {
       "from": "port",
-      "numberlessName": "console_line_#",
-      "event": "loiqe-key"
-    }
+      "name": "mainpanel_thruster"
+    },
+    "index": 158,
+    "type": "hit"
   },
   {
-    "type": "hit",
     "data": {
       "from": "port",
-      "numberlessName": "valen-Bank_slot_#",
-      "event": null
-    }
+      "name": "mainpanel_radar"
+    },
+    "index": 159,
+    "type": "hit"
   },
-  { "type": "upload", "data": "valen-Bank_slot_#" },
   {
-    "type": "hit",
     "data": {
       "from": "port",
-      "numberlessName": "console_line_#",
-      "event": "senni-key"
-    }
+      "name": "mainpanel_radar"
+    },
+    "index": 160,
+    "type": "hit"
   },
   {
-    "type": "hit",
     "data": {
       "from": "port",
-      "numberlessName": "valen-Bank_slot_#",
-      "event": null
-    }
+      "name": "valen-portal_pilot"
+    },
+    "index": 161,
+    "type": "hit"
   },
-  { "type": "upload", "data": "valen-Bank_slot_#" },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "location_valen-harvest" }
+    "data": {
+      "from": "port",
+      "name": "mainpanel_pilot"
+    },
+    "index": 162,
+    "type": "hit"
   },
-  { "type": "pilotAligned", "data": "harvest" },
-  { "type": "hit", "data": { "from": "trigger", "name": "thruster_action" } },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": {
+      "from": "trigger",
+      "name": "thruster_action"
+    },
+    "index": 163,
+    "type": "hit"
   },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": "portal",
+    "index": 164,
+    "type": "docked"
   },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": {
+      "from": "port",
+      "name": "mainpanel_radar"
+    },
+    "index": 165,
+    "type": "hit"
   },
-  { "type": "docked", "data": "harvest" },
-  { "type": "hit", "data": { "from": "port", "name": "widget_radio" } },
-  { "type": "hit", "data": { "from": "port", "name": "mainpanel_cargo" } },
-  { "type": "upload", "data": "cargo" },
-  { "type": "hit", "data": { "from": "port", "name": "valen-harvest_ikov" } },
-  { "type": "hit", "data": { "from": "port", "name": "mainpanel_cargo" } },
-  { "type": "upload", "data": "cargo" },
-  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
-  { "type": "hit", "data": { "from": "port", "name": "player" } },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "location_senni-Horadric" }
+    "data": {
+      "from": "port",
+      "name": "mainpanel_pilot"
+    },
+    "index": 166,
+    "type": "hit"
   },
-  { "type": "pilotAligned", "data": "Horadric" },
-  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
-  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
-  { "type": "hit", "data": { "from": "trigger", "name": "thruster_action" } },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": {
+      "from": "trigger",
+      "name": "location_loiqe-satellite"
+    },
+    "index": 167,
+    "type": "hit"
   },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": "satellite",
+    "index": 168,
+    "type": "pilotAligned"
   },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": {
+      "from": "trigger",
+      "name": "thruster_action"
+    },
+    "index": 169,
+    "type": "hit"
   },
-  { "type": "docked", "data": "Horadric" },
   {
-    "type": "hit",
     "data": {
-      "from": "port",
-      "numberlessName": "console_line_#",
-      "event": "currency-2"
-    }
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 170,
+    "type": "hit"
   },
   {
-    "type": "hit",
     "data": {
-      "from": "port",
-      "numberlessName": "senni-Horadric_input_#",
-      "event": null
-    }
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 171,
+    "type": "hit"
   },
-  { "type": "upload", "data": "senni-Horadric_input_#" },
   {
-    "type": "hit",
-    "data": {
-      "from": "port",
-      "numberlessName": "console_line_#",
-      "event": "currency-3"
-    }
+    "data": "satellite",
+    "index": 172,
+    "type": "docked"
   },
   {
-    "type": "hit",
     "data": {
-      "from": "port",
-      "numberlessName": "senni-Horadric_input_#",
-      "event": null
-    }
+      "from": "trigger",
+      "name": "location_loiqe-City"
+    },
+    "index": 173,
+    "type": "hit"
   },
-  { "type": "combination", "data": "ikeral" },
   {
-    "type": "hit",
-    "data": { "from": "port", "name": "senni-Horadric_output_1" }
+    "data": "City",
+    "index": 174,
+    "type": "pilotAligned"
   },
-  { "type": "hit", "data": { "from": "port", "name": "mainpanel_cargo" } },
-  { "type": "upload", "data": "cargo" },
   {
-    "type": "hit",
     "data": {
-      "from": "port",
-      "numberlessName": "console_line_#",
-      "event": "record1"
-    }
+      "from": "trigger",
+      "name": "thruster_action"
+    },
+    "index": 175,
+    "type": "hit"
   },
   {
-    "type": "hit",
     "data": {
-      "from": "port",
-      "numberlessName": "senni-Horadric_input_#",
-      "event": null
-    }
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 176,
+    "type": "hit"
   },
-  { "type": "upload", "data": "senni-Horadric_input_#" },
   {
-    "type": "hit",
     "data": {
-      "from": "port",
-      "numberlessName": "console_line_#",
-      "event": "record2"
-    }
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 177,
+    "type": "hit"
+  },
+  {
+    "data": "City",
+    "index": 178,
+    "type": "docked"
   },
   {
-    "type": "hit",
     "data": {
-      "from": "port",
-      "numberlessName": "senni-Horadric_input_#",
-      "event": null
-    }
+      "from": "trigger",
+      "name": "location_loiqe-Harvest"
+    },
+    "index": 179,
+    "type": "hit"
   },
-  { "type": "combination", "data": "cassette" },
   {
-    "type": "hit",
-    "data": { "from": "port", "name": "senni-Horadric_output_1" }
+    "data": "Harvest",
+    "index": 180,
+    "type": "pilotAligned"
   },
-  { "type": "hit", "data": { "from": "port", "name": "widget_radio" } },
-  { "type": "upload", "data": "widget_radio" },
-  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
-  { "type": "hit", "data": { "from": "port", "name": "player" } },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "location_senni-fog" }
+    "data": {
+      "from": "trigger",
+      "name": "thruster_action"
+    },
+    "index": 181,
+    "type": "hit"
   },
-  { "type": "pilotAligned", "data": "fog" },
-  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
-  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
-  { "type": "hit", "data": { "from": "trigger", "name": "thruster_action" } },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 182,
+    "type": "hit"
   },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 183,
+    "type": "hit"
   },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": "Harvest",
+    "index": 184,
+    "type": "docked"
   },
-  { "type": "docked", "data": "fog" },
-  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
-  { "type": "hit", "data": { "from": "port", "name": "player" } },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "location_valen-portal" }
+    "data": {
+      "from": "port",
+      "name": "loiqe-Harvest_alta"
+    },
+    "index": 185,
+    "type": "hit"
   },
-  { "type": "pilotAligned", "data": "portal" },
-  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
-  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
-  { "type": "hit", "data": { "from": "trigger", "name": "thruster_action" } },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": {
+      "from": "port",
+      "name": "mainpanel_cargo"
+    },
+    "index": 186,
+    "type": "hit"
   },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": "cargo",
+    "index": 187,
+    "type": "upload"
   },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": {
+      "from": "trigger",
+      "name": "location_loiqe-City"
+    },
+    "index": 188,
+    "type": "hit"
   },
-  { "type": "docked", "data": "portal" },
-  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
-  { "type": "hit", "data": { "from": "port", "name": "player" } },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "location_loiqe-portal" }
+    "data": "City",
+    "index": 189,
+    "type": "pilotAligned"
   },
-  { "type": "pilotAligned", "data": "portal" },
-  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
-  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
-  { "type": "hit", "data": { "from": "trigger", "name": "thruster_action" } },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": {
+      "from": "trigger",
+      "name": "thruster_action"
+    },
+    "index": 190,
+    "type": "hit"
   },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 191,
+    "type": "hit"
   },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 192,
+    "type": "hit"
   },
-  { "type": "docked", "data": "portal" },
-  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
-  { "type": "hit", "data": { "from": "port", "name": "player" } },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "location_loiqe-fog" }
+    "data": "City",
+    "index": 193,
+    "type": "docked"
   },
-  { "type": "pilotAligned", "data": "fog" },
-  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
-  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
-  { "type": "hit", "data": { "from": "trigger", "name": "thruster_action" } },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": {
+      "from": "trigger",
+      "name": "location_loiqe-satellite"
+    },
+    "index": 194,
+    "type": "hit"
   },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": "satellite",
+    "index": 195,
+    "type": "pilotAligned"
   },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": {
+      "from": "trigger",
+      "name": "thruster_action"
+    },
+    "index": 196,
+    "type": "hit"
   },
-  { "type": "docked", "data": "fog" },
   {
-    "type": "hit",
     "data": {
-      "from": "port",
-      "numberlessName": "console_line_#",
-      "event": "currency-5"
-    }
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 197,
+    "type": "hit"
   },
-  { "type": "hit", "data": { "from": "port", "name": "loiqe-fog_want" } },
-  { "type": "upload", "data": "loiqe-fog_want" },
-  { "type": "hit", "data": { "from": "port", "name": "loiqe-fog_give" } },
-  { "type": "hit", "data": { "from": "port", "name": "mainpanel_cargo" } },
-  { "type": "upload", "data": "cargo" },
-  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
-  { "type": "hit", "data": { "from": "port", "name": "player" } },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "location_loiqe-portal" }
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 198,
+    "type": "hit"
   },
-  { "type": "pilotAligned", "data": "portal" },
-  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
-  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
-  { "type": "hit", "data": { "from": "trigger", "name": "thruster_action" } },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": "satellite",
+    "index": 199,
+    "type": "docked"
   },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": {
+      "from": "trigger",
+      "name": "location_loiqe-Horadric"
+    },
+    "index": 200,
+    "type": "hit"
   },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": "Horadric",
+    "index": 201,
+    "type": "pilotAligned"
   },
-  { "type": "docked", "data": "portal" },
-  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
-  { "type": "hit", "data": { "from": "port", "name": "player" } },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "location_loiqe-Horadric" }
+    "data": {
+      "from": "trigger",
+      "name": "thruster_action"
+    },
+    "index": 202,
+    "type": "hit"
   },
-  { "type": "pilotAligned", "data": "Horadric" },
-  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
-  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
-  { "type": "hit", "data": { "from": "trigger", "name": "thruster_action" } },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 203,
+    "type": "hit"
   },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 204,
+    "type": "hit"
   },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": "Horadric",
+    "index": 205,
+    "type": "docked"
   },
-  { "type": "docked", "data": "Horadric" },
   {
-    "type": "hit",
     "data": {
+      "event": "currency-1",
       "from": "port",
-      "numberlessName": "console_line_#",
-      "event": "usul-key-1"
-    }
+      "numberlessName": "console_line_#"
+    },
+    "index": 206,
+    "type": "hit"
   },
   {
-    "type": "hit",
     "data": {
+      "event": null,
       "from": "port",
-      "numberlessName": "loiqe-Horadric_input_#",
-      "event": null
-    }
+      "numberlessName": "loiqe-Horadric_input_#"
+    },
+    "index": 207,
+    "type": "hit"
   },
-  { "type": "upload", "data": "loiqe-Horadric_input_#" },
   {
-    "type": "hit",
-    "data": {
-      "from": "port",
-      "numberlessName": "console_line_#",
-      "event": "usul-key-2"
-    }
+    "data": "loiqe-Horadric_input_#",
+    "index": 208,
+    "type": "upload"
   },
   {
-    "type": "hit",
     "data": {
+      "event": "currency-2",
       "from": "port",
-      "numberlessName": "loiqe-Horadric_input_#",
-      "event": null
-    }
+      "numberlessName": "console_line_#"
+    },
+    "index": 209,
+    "type": "hit"
   },
-  { "type": "combination", "data": "usul key" },
   {
-    "type": "hit",
-    "data": { "from": "port", "name": "loiqe-Horadric_output_1" }
+    "data": {
+      "event": null,
+      "from": "port",
+      "numberlessName": "loiqe-Horadric_input_#"
+    },
+    "index": 210,
+    "type": "hit"
   },
-  { "type": "hit", "data": { "from": "port", "name": "mainpanel_cargo" } },
-  { "type": "upload", "data": "cargo" },
-  { "type": "hit", "data": { "from": "port", "name": "widget_radio" } },
-  { "type": "hit", "data": { "from": "port", "name": "mainpanel_cargo" } },
-  { "type": "upload", "data": "cargo" },
-  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
-  { "type": "hit", "data": { "from": "port", "name": "player" } },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "location_loiqe-portal" }
+    "data": "altiov",
+    "index": 211,
+    "type": "combination"
   },
-  { "type": "pilotAligned", "data": "portal" },
-  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
-  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
-  { "type": "hit", "data": { "from": "trigger", "name": "thruster_action" } },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": {
+      "from": "port",
+      "name": "loiqe-Horadric_output_1"
+    },
+    "index": 212,
+    "type": "hit"
   },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": {
+      "from": "port",
+      "name": "mainpanel_cargo"
+    },
+    "index": 213,
+    "type": "hit"
   },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": "cargo",
+    "index": 214,
+    "type": "upload"
   },
-  { "type": "docked", "data": "portal" },
   {
-    "type": "hit",
     "data": {
-      "from": "port",
-      "numberlessName": "console_line_#",
-      "event": "usul-key"
-    }
+      "from": "trigger",
+      "name": "location_loiqe-satellite"
+    },
+    "index": 215,
+    "type": "hit"
   },
-  { "type": "hit", "data": { "from": "port", "name": "mainpanel_mission" } },
   {
-    "type": "hit",
-    "data": { "from": "port", "name": "loiqe-portal_thruster" }
+    "data": "satellite",
+    "index": 216,
+    "type": "pilotAligned"
   },
-  { "type": "hit", "data": { "from": "port", "name": "mainpanel_thruster" } },
-  { "type": "hit", "data": { "from": "port", "name": "mainpanel_radar" } },
-  { "type": "hit", "data": { "from": "port", "name": "mainpanel_radar" } },
-  { "type": "hit", "data": { "from": "port", "name": "loiqe-portal_pilot" } },
-  { "type": "hit", "data": { "from": "port", "name": "mainpanel_pilot" } },
-  { "type": "pilotAligned", "data": "portal" },
-  { "type": "hit", "data": { "from": "trigger", "name": "thruster_action" } },
-  { "type": "docked", "data": "portal" },
-  { "type": "hit", "data": { "from": "port", "name": "mainpanel_radar" } },
-  { "type": "hit", "data": { "from": "port", "name": "mainpanel_pilot" } },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "location_usul-station" }
+    "data": {
+      "from": "trigger",
+      "name": "thruster_action"
+    },
+    "index": 217,
+    "type": "hit"
   },
-  { "type": "hit", "data": { "from": "trigger", "name": "thruster_action" } },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 218,
+    "type": "hit"
   },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 219,
+    "type": "hit"
   },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": "satellite",
+    "index": 220,
+    "type": "docked"
   },
-  { "type": "docked", "data": "station" },
-  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
-  { "type": "hit", "data": { "from": "port", "name": "player" } },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "location_senni-transit" }
+    "data": {
+      "from": "trigger",
+      "name": "location_loiqe-portal"
+    },
+    "index": 221,
+    "type": "hit"
   },
-  { "type": "pilotAligned", "data": "transit" },
-  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
-  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
-  { "type": "hit", "data": { "from": "trigger", "name": "thruster_action" } },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": "portal",
+    "index": 222,
+    "type": "pilotAligned"
   },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": {
+      "from": "trigger",
+      "name": "thruster_action"
+    },
+    "index": 223,
+    "type": "hit"
   },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 224,
+    "type": "hit"
   },
-  { "type": "docked", "data": "transit" },
-  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
-  { "type": "hit", "data": { "from": "port", "name": "player" } },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "location_valen-Bank" }
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 225,
+    "type": "hit"
   },
-  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
-  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
-  { "type": "hit", "data": { "from": "trigger", "name": "thruster_action" } },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": "portal",
+    "index": 226,
+    "type": "docked"
   },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": {
+      "from": "trigger",
+      "name": "location_loiqe-port"
+    },
+    "index": 227,
+    "type": "hit"
   },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": "port",
+    "index": 228,
+    "type": "pilotAligned"
   },
-  { "type": "docked", "data": "Bank" },
   {
-    "type": "hit",
     "data": {
-      "from": "port",
-      "numberlessName": "console_line_#",
-      "event": "record3"
-    }
+      "from": "trigger",
+      "name": "thruster_action"
+    },
+    "index": 229,
+    "type": "hit"
   },
   {
-    "type": "hit",
     "data": {
-      "from": "port",
-      "numberlessName": "valen-Bank_slot_#",
-      "event": null
-    }
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 230,
+    "type": "hit"
   },
-  { "type": "upload", "data": "valen-Bank_slot_#" },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "location_valen-harvest" }
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 231,
+    "type": "hit"
   },
-  { "type": "pilotAligned", "data": "harvest" },
-  { "type": "hit", "data": { "from": "trigger", "name": "thruster_action" } },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": "port",
+    "index": 232,
+    "type": "docked"
   },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": {
+      "event": "currency-4",
+      "from": "port",
+      "numberlessName": "console_line_#"
+    },
+    "index": 233,
+    "type": "hit"
   },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": {
+      "from": "port",
+      "name": "loiqe-port_want"
+    },
+    "index": 234,
+    "type": "hit"
   },
-  { "type": "docked", "data": "harvest" },
-  { "type": "hit", "data": { "from": "port", "name": "valen-harvest_ikov" } },
-  { "type": "hit", "data": { "from": "port", "name": "mainpanel_cargo" } },
-  { "type": "upload", "data": "cargo" },
-  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
-  { "type": "hit", "data": { "from": "port", "name": "player" } },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "location_senni-harvest" }
+    "data": "loiqe-port_want",
+    "index": 235,
+    "type": "upload"
   },
-  { "type": "pilotAligned", "data": "harvest" },
-  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
-  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
-  { "type": "hit", "data": { "from": "trigger", "name": "thruster_action" } },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": {
+      "from": "port",
+      "name": "loiqe-port_give"
+    },
+    "index": 236,
+    "type": "hit"
   },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": {
+      "from": "port",
+      "name": "mainpanel_cargo"
+    },
+    "index": 237,
+    "type": "hit"
   },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": "cargo",
+    "index": 238,
+    "type": "upload"
   },
-  { "type": "docked", "data": "harvest" },
-  { "type": "hit", "data": { "from": "port", "name": "senni-harvest_eral" } },
-  { "type": "hit", "data": { "from": "port", "name": "mainpanel_cargo" } },
-  { "type": "upload", "data": "cargo" },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "location_senni-Horadric" }
+    "data": {
+      "from": "trigger",
+      "name": "location_loiqe-portal"
+    },
+    "index": 239,
+    "type": "hit"
   },
-  { "type": "pilotAligned", "data": "Horadric" },
-  { "type": "hit", "data": { "from": "trigger", "name": "thruster_action" } },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": "portal",
+    "index": 240,
+    "type": "pilotAligned"
   },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": {
+      "from": "trigger",
+      "name": "thruster_action"
+    },
+    "index": 241,
+    "type": "hit"
   },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 242,
+    "type": "hit"
   },
-  { "type": "docked", "data": "Horadric" },
   {
-    "type": "hit",
     "data": {
-      "from": "port",
-      "numberlessName": "console_line_#",
-      "event": "currency-2"
-    }
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 243,
+    "type": "hit"
   },
   {
-    "type": "hit",
+    "data": "portal",
+    "index": 244,
+    "type": "docked"
+  },
+  {
     "data": {
+      "event": "senni-key",
       "from": "port",
-      "numberlessName": "senni-Horadric_input_#",
-      "event": null
-    }
+      "numberlessName": "console_line_#"
+    },
+    "index": 245,
+    "type": "hit"
   },
-  { "type": "upload", "data": "senni-Horadric_input_#" },
   {
-    "type": "hit",
     "data": {
       "from": "port",
-      "numberlessName": "console_line_#",
-      "event": "currency-3"
-    }
+      "name": "mainpanel_mission"
+    },
+    "index": 246,
+    "type": "hit"
   },
   {
-    "type": "hit",
     "data": {
       "from": "port",
-      "numberlessName": "senni-Horadric_input_#",
-      "event": null
-    }
+      "name": "loiqe-portal_thruster"
+    },
+    "index": 247,
+    "type": "hit"
   },
-  { "type": "combination", "data": "ikeral" },
   {
-    "type": "hit",
-    "data": { "from": "port", "name": "senni-Horadric_output_1" }
+    "data": {
+      "from": "port",
+      "name": "mainpanel_thruster"
+    },
+    "index": 248,
+    "type": "hit"
   },
-  { "type": "hit", "data": { "from": "port", "name": "mainpanel_cargo" } },
-  { "type": "upload", "data": "cargo" },
-  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
-  { "type": "hit", "data": { "from": "port", "name": "player" } },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "location_senni-wreck" }
+    "data": {
+      "from": "port",
+      "name": "mainpanel_radar"
+    },
+    "index": 249,
+    "type": "hit"
   },
-  { "type": "pilotAligned", "data": "wreck" },
-  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
-  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
-  { "type": "hit", "data": { "from": "trigger", "name": "thruster_action" } },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": {
+      "from": "port",
+      "name": "mainpanel_radar"
+    },
+    "index": 250,
+    "type": "hit"
   },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": {
+      "from": "port",
+      "name": "loiqe-portal_pilot"
+    },
+    "index": 251,
+    "type": "hit"
   },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": {
+      "from": "port",
+      "name": "mainpanel_pilot"
+    },
+    "index": 252,
+    "type": "hit"
   },
-  { "type": "docked", "data": "wreck" },
-  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
-  { "type": "hit", "data": { "from": "port", "name": "player" } },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "location_usul-station" }
+    "data": "portal",
+    "index": 253,
+    "type": "pilotAligned"
   },
-  { "type": "pilotAligned", "data": "station" },
-  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
-  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
-  { "type": "hit", "data": { "from": "trigger", "name": "thruster_action" } },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": {
+      "from": "trigger",
+      "name": "thruster_action"
+    },
+    "index": 254,
+    "type": "hit"
   },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": "portal",
+    "index": 255,
+    "type": "docked"
   },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": {
+      "from": "port",
+      "name": "mainpanel_radar"
+    },
+    "index": 256,
+    "type": "hit"
   },
-  { "type": "docked", "data": "station" },
   {
-    "type": "hit",
     "data": {
       "from": "port",
-      "numberlessName": "console_line_#",
-      "event": "currency-5"
-    }
+      "name": "mainpanel_pilot"
+    },
+    "index": 257,
+    "type": "hit"
   },
-  { "type": "hit", "data": { "from": "port", "name": "usul-station" } },
-  { "type": "upload", "data": "usul-station" },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "button_usul-station_install" }
+    "data": {
+      "from": "trigger",
+      "name": "thruster_action"
+    },
+    "index": 258,
+    "type": "hit"
   },
-  { "skip": true, "type": "mission", "data": 15 },
-  { "type": "playerUnlock", "data": 0 },
   {
-    "type": "hit",
     "data": {
-      "from": "port",
-      "numberlessName": "battery_slot_cell#",
-      "event": "battery-3"
-    }
+      "from": "trigger",
+      "name": "location_senni-cargo"
+    },
+    "index": 259,
+    "type": "hit"
   },
-  { "type": "hit", "data": { "from": "port", "name": "battery_slot_oxygen" } },
-  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
-  { "type": "hit", "data": { "from": "port", "name": "player" } },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "location_valen-Bank" }
+    "data": "cargo",
+    "index": 260,
+    "type": "pilotAligned"
   },
-  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
-  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
-  { "type": "hit", "data": { "from": "trigger", "name": "thruster_action" } },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 261,
+    "type": "hit"
   },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 262,
+    "type": "hit"
   },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": "cargo",
+    "index": 263,
+    "type": "docked"
   },
-  { "type": "docked", "data": "Bank" },
   {
-    "type": "hit",
     "data": {
       "from": "port",
-      "numberlessName": "valen-Bank_slot_#",
-      "event": "valen-key"
-    }
+      "name": "senni-cargo_Fog Map"
+    },
+    "index": 264,
+    "type": "hit"
   },
-  { "type": "hit", "data": { "from": "port", "name": "mainpanel_cargo" } },
-  { "type": "upload", "data": "cargo" },
   {
-    "type": "hit",
     "data": {
       "from": "port",
-      "numberlessName": "valen-Bank_slot_#",
-      "event": "loiqe-key"
-    }
+      "name": "mainpanel_cargo"
+    },
+    "index": 265,
+    "type": "hit"
   },
-  { "type": "hit", "data": { "from": "port", "name": "mainpanel_cargo" } },
-  { "type": "upload", "data": "cargo" },
   {
-    "type": "hit",
-    "data": {
-      "from": "port",
-      "numberlessName": "valen-Bank_slot_#",
-      "event": "senni-key"
-    }
+    "data": "cargo",
+    "index": 266,
+    "type": "upload"
   },
-  { "type": "hit", "data": { "from": "port", "name": "mainpanel_cargo" } },
-  { "type": "upload", "data": "cargo" },
   {
-    "type": "hit",
     "data": {
-      "from": "port",
-      "numberlessName": "valen-Bank_slot_#",
-      "event": "record3"
-    }
+      "from": "trigger",
+      "name": "location_senni-harvest"
+    },
+    "index": 267,
+    "type": "hit"
+  },
+  {
+    "data": "harvest",
+    "index": 268,
+    "type": "pilotAligned"
   },
-  { "type": "hit", "data": { "from": "port", "name": "mainpanel_cargo" } },
-  { "type": "upload", "data": "cargo" },
-  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
-  { "type": "hit", "data": { "from": "port", "name": "player" } },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "location_senni-Horadric" }
+    "data": {
+      "from": "trigger",
+      "name": "thruster_action"
+    },
+    "index": 269,
+    "type": "hit"
   },
-  { "type": "pilotAligned", "data": "Horadric" },
-  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
-  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
-  { "type": "hit", "data": { "from": "trigger", "name": "thruster_action" } },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 270,
+    "type": "hit"
   },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 271,
+    "type": "hit"
   },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": "harvest",
+    "index": 272,
+    "type": "docked"
   },
-  { "type": "docked", "data": "Horadric" },
   {
-    "type": "hit",
     "data": {
       "from": "port",
-      "numberlessName": "console_line_#",
-      "event": "usul-key"
-    }
+      "name": "senni-harvest_eral"
+    },
+    "index": 273,
+    "type": "hit"
   },
   {
-    "type": "hit",
     "data": {
       "from": "port",
-      "numberlessName": "senni-Horadric_input_#",
-      "event": null
-    }
+      "name": "mainpanel_cargo"
+    },
+    "index": 274,
+    "type": "hit"
+  },
+  {
+    "data": "cargo",
+    "index": 275,
+    "type": "upload"
   },
-  { "type": "upload", "data": "senni-Horadric_input_#" },
   {
-    "type": "hit",
     "data": {
-      "from": "port",
-      "numberlessName": "console_line_#",
-      "event": "valen-key"
-    }
+      "from": "trigger",
+      "name": "location_senni-station"
+    },
+    "index": 276,
+    "type": "hit"
+  },
+  {
+    "data": "station",
+    "index": 277,
+    "type": "pilotAligned"
   },
   {
-    "type": "hit",
     "data": {
-      "from": "port",
-      "numberlessName": "senni-Horadric_input_#",
-      "event": null
-    }
+      "from": "trigger",
+      "name": "thruster_action"
+    },
+    "index": 278,
+    "type": "hit"
   },
-  { "type": "combination", "data": "horizontal part" },
   {
-    "type": "hit",
-    "data": { "from": "port", "name": "senni-Horadric_output_1" }
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 279,
+    "type": "hit"
   },
-  { "type": "hit", "data": { "from": "port", "name": "mainpanel_cargo" } },
-  { "type": "upload", "data": "cargo" },
   {
-    "type": "hit",
     "data": {
-      "from": "port",
-      "numberlessName": "console_line_#",
-      "event": "loiqe-key"
-    }
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 280,
+    "type": "hit"
+  },
+  {
+    "data": "station",
+    "index": 281,
+    "type": "docked"
   },
   {
-    "type": "hit",
     "data": {
+      "event": "currency-3",
       "from": "port",
-      "numberlessName": "senni-Horadric_input_#",
-      "event": null
-    }
+      "numberlessName": "console_line_#"
+    },
+    "index": 282,
+    "type": "hit"
   },
-  { "type": "upload", "data": "senni-Horadric_input_#" },
   {
-    "type": "hit",
     "data": {
       "from": "port",
-      "numberlessName": "console_line_#",
-      "event": "senni-key"
-    }
+      "name": "senni-station"
+    },
+    "index": 283,
+    "type": "hit"
+  },
+  {
+    "data": "senni-station",
+    "index": 284,
+    "type": "upload"
   },
   {
-    "type": "hit",
     "data": {
-      "from": "port",
-      "numberlessName": "senni-Horadric_input_#",
-      "event": null
-    }
+      "from": "trigger",
+      "name": "button_senni-station_install"
+    },
+    "index": 285,
+    "type": "hit"
   },
-  { "type": "combination", "data": "vertical part" },
   {
-    "type": "hit",
-    "data": { "from": "port", "name": "senni-Horadric_output_1" }
+    "data": -90,
+    "index": 286,
+    "type": "playerUnlock"
   },
-  { "type": "hit", "data": { "from": "port", "name": "mainpanel_cargo" } },
-  { "type": "upload", "data": "cargo" },
   {
-    "type": "hit",
     "data": {
+      "event": "battery-2",
       "from": "port",
-      "numberlessName": "console_line_#",
-      "event": "end-key-1"
-    }
+      "numberlessName": "battery_slot_cell#"
+    },
+    "index": 287,
+    "type": "hit"
   },
   {
-    "type": "hit",
     "data": {
       "from": "port",
-      "numberlessName": "senni-Horadric_input_#",
-      "event": null
-    }
+      "name": "battery_slot_cloak"
+    },
+    "index": 288,
+    "type": "hit"
   },
-  { "type": "upload", "data": "senni-Horadric_input_#" },
   {
-    "type": "hit",
     "data": {
+      "event": "map-1",
       "from": "port",
-      "numberlessName": "console_line_#",
-      "event": "end-key-2"
-    }
+      "numberlessName": "console_line_#"
+    },
+    "index": 289,
+    "type": "hit"
   },
   {
-    "type": "hit",
     "data": {
       "from": "port",
-      "numberlessName": "senni-Horadric_input_#",
-      "event": null
-    }
+      "name": "widget_map"
+    },
+    "index": 290,
+    "type": "hit"
   },
-  { "type": "combination", "data": "End Key" },
   {
-    "type": "hit",
-    "data": { "from": "port", "name": "senni-Horadric_output_1" }
+    "data": "widget_map",
+    "index": 291,
+    "type": "upload"
   },
-  { "type": "hit", "data": { "from": "port", "name": "mainpanel_cargo" } },
-  { "type": "upload", "data": "cargo" },
-  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
-  { "type": "hit", "data": { "from": "port", "name": "player" } },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "location_senni-wreck" }
+    "data": {
+      "from": "trigger",
+      "name": "location_senni-fog"
+    },
+    "index": 292,
+    "type": "hit"
   },
-  { "type": "pilotAligned", "data": "wreck" },
-  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
-  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
-  { "type": "hit", "data": { "from": "trigger", "name": "thruster_action" } },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": {
+      "from": "trigger",
+      "name": "thruster_action"
+    },
+    "index": 293,
+    "type": "hit"
   },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 294,
+    "type": "hit"
   },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 295,
+    "type": "hit"
   },
-  { "type": "docked", "data": "wreck" },
-  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
-  { "type": "hit", "data": { "from": "port", "name": "player" } },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "location_usul-station" }
+    "data": "fog",
+    "index": 296,
+    "type": "docked"
   },
-  { "type": "pilotAligned", "data": "station" },
-  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
-  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
-  { "type": "hit", "data": { "from": "trigger", "name": "thruster_action" } },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": {
+      "from": "port",
+      "name": "senni-fog_cell"
+    },
+    "index": 297,
+    "type": "hit"
   },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": {
+      "from": "port",
+      "name": "mainpanel_cargo"
+    },
+    "index": 298,
+    "type": "hit"
   },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": "cargo",
+    "index": 299,
+    "type": "upload"
   },
-  { "type": "docked", "data": "station" },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "location_usul-portal" }
-  },
-  { "type": "pilotAligned", "data": "portal" },
-  { "type": "hit", "data": { "from": "trigger", "name": "thruster_action" } },
+    "data": {
+      "event": "battery-3",
+      "from": "port",
+      "numberlessName": "console_line_#"
+    },
+    "index": 300,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "event": null,
+      "from": "port",
+      "numberlessName": "battery_slot_cell#"
+    },
+    "index": 301,
+    "type": "hit"
+  },
+  {
+    "data": 12,
+    "index": 302,
+    "skip": true,
+    "type": "mission"
+  },
+  {
+    "data": "battery_slot_cell#",
+    "index": 303,
+    "type": "upload"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "widget_map"
+    },
+    "index": 304,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "player"
+    },
+    "index": 305,
+    "type": "hit"
+  },
+  {
+    "data": 13,
+    "index": 306,
+    "type": "mission"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "location_valen-harvest"
+    },
+    "index": 307,
+    "type": "hit"
+  },
+  {
+    "data": "harvest",
+    "index": 308,
+    "type": "pilotAligned"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "widget_map"
+    },
+    "index": 309,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "widget_map"
+    },
+    "index": 310,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "thruster_action"
+    },
+    "index": 311,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 312,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 313,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 314,
+    "type": "hit"
+  },
+  {
+    "data": "harvest",
+    "index": 315,
+    "type": "docked"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "location_valen-station"
+    },
+    "index": 316,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "thruster_action"
+    },
+    "index": 317,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 318,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 319,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 320,
+    "type": "hit"
+  },
+  {
+    "data": "station",
+    "index": 321,
+    "type": "docked"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "widget_map"
+    },
+    "index": 322,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "player"
+    },
+    "index": 323,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "location_valen-fog"
+    },
+    "index": 324,
+    "type": "hit"
+  },
+  {
+    "data": "fog",
+    "index": 325,
+    "type": "pilotAligned"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "widget_map"
+    },
+    "index": 326,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "widget_map"
+    },
+    "index": 327,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "thruster_action"
+    },
+    "index": 328,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 329,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 330,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 331,
+    "type": "hit"
+  },
+  {
+    "data": "fog",
+    "index": 332,
+    "type": "docked"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "valen-fog_usul Part 1"
+    },
+    "index": 333,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "mainpanel_cargo"
+    },
+    "index": 334,
+    "type": "hit"
+  },
+  {
+    "data": "cargo",
+    "index": 335,
+    "type": "upload"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "widget_map"
+    },
+    "index": 336,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "player"
+    },
+    "index": 337,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "location_loiqe-Horadric"
+    },
+    "index": 338,
+    "type": "hit"
+  },
+  {
+    "data": "Horadric",
+    "index": 339,
+    "type": "pilotAligned"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "widget_map"
+    },
+    "index": 340,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "widget_map"
+    },
+    "index": 341,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "thruster_action"
+    },
+    "index": 342,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 343,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 344,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 345,
+    "type": "hit"
+  },
+  {
+    "data": "Horadric",
+    "index": 346,
+    "type": "docked"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "widget_map"
+    },
+    "index": 347,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "player"
+    },
+    "index": 348,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "location_loiqe-portal"
+    },
+    "index": 349,
+    "type": "hit"
+  },
+  {
+    "data": "portal",
+    "index": 350,
+    "type": "pilotAligned"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "widget_map"
+    },
+    "index": 351,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "widget_map"
+    },
+    "index": 352,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "thruster_action"
+    },
+    "index": 353,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 354,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 355,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 356,
+    "type": "hit"
+  },
+  {
+    "data": "portal",
+    "index": 357,
+    "type": "docked"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "widget_map"
+    },
+    "index": 358,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "player"
+    },
+    "index": 359,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "location_loiqe-fog"
+    },
+    "index": 360,
+    "type": "hit"
+  },
+  {
+    "data": "fog",
+    "index": 361,
+    "type": "pilotAligned"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "widget_map"
+    },
+    "index": 362,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "widget_map"
+    },
+    "index": 363,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "thruster_action"
+    },
+    "index": 364,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 365,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 366,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 367,
+    "type": "hit"
+  },
+  {
+    "data": "fog",
+    "index": 368,
+    "type": "docked"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "widget_map"
+    },
+    "index": 369,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "player"
+    },
+    "index": 370,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "location_loiqe-portal"
+    },
+    "index": 371,
+    "type": "hit"
+  },
+  {
+    "data": "portal",
+    "index": 372,
+    "type": "pilotAligned"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "widget_map"
+    },
+    "index": 373,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "widget_map"
+    },
+    "index": 374,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "thruster_action"
+    },
+    "index": 375,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 376,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 377,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 378,
+    "type": "hit"
+  },
+  {
+    "data": "portal",
+    "index": 379,
+    "type": "docked"
+  },
+  {
+    "data": {
+      "event": "senni-key",
+      "from": "port",
+      "numberlessName": "console_line_#"
+    },
+    "index": 380,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "mainpanel_mission"
+    },
+    "index": 381,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "loiqe-portal_thruster"
+    },
+    "index": 382,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "mainpanel_thruster"
+    },
+    "index": 383,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "mainpanel_radar"
+    },
+    "index": 384,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "mainpanel_radar"
+    },
+    "index": 385,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "loiqe-portal_pilot"
+    },
+    "index": 386,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "mainpanel_pilot"
+    },
+    "index": 387,
+    "type": "hit"
+  },
+  {
+    "data": "portal",
+    "index": 388,
+    "type": "pilotAligned"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "thruster_action"
+    },
+    "index": 389,
+    "type": "hit"
+  },
+  {
+    "data": "portal",
+    "index": 390,
+    "type": "docked"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "mainpanel_radar"
+    },
+    "index": 391,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "mainpanel_pilot"
+    },
+    "index": 392,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "widget_map"
+    },
+    "index": 393,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "player"
+    },
+    "index": 394,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "location_senni-wreck"
+    },
+    "index": 395,
+    "type": "hit"
+  },
+  {
+    "data": "wreck",
+    "index": 396,
+    "type": "pilotAligned"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "widget_map"
+    },
+    "index": 397,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "widget_map"
+    },
+    "index": 398,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "thruster_action"
+    },
+    "index": 399,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 400,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 401,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 402,
+    "type": "hit"
+  },
+  {
+    "data": "wreck",
+    "index": 403,
+    "type": "docked"
+  },
+  {
+    "data": {
+      "event": "battery-3",
+      "from": "port",
+      "numberlessName": "battery_slot_cell#"
+    },
+    "index": 404,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "battery_slot_radio"
+    },
+    "index": 405,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "widget_radio"
+    },
+    "index": 406,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "mainpanel_cargo"
+    },
+    "index": 407,
+    "type": "hit"
+  },
+  {
+    "data": "cargo",
+    "index": 408,
+    "type": "upload"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "senni-wreck_disk"
+    },
+    "index": 409,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "widget_radio"
+    },
+    "index": 410,
+    "type": "hit"
+  },
+  {
+    "data": "widget_radio",
+    "index": 411,
+    "type": "upload"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "widget_map"
+    },
+    "index": 412,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "player"
+    },
+    "index": 413,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "location_senni-harvest"
+    },
+    "index": 414,
+    "type": "hit"
+  },
+  {
+    "data": "harvest",
+    "index": 415,
+    "type": "pilotAligned"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "widget_map"
+    },
+    "index": 416,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "widget_map"
+    },
+    "index": 417,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "thruster_action"
+    },
+    "index": 418,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 419,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 420,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 421,
+    "type": "hit"
+  },
+  {
+    "data": "harvest",
+    "index": 422,
+    "type": "docked"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "senni-harvest_eral"
+    },
+    "index": 423,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "mainpanel_cargo"
+    },
+    "index": 424,
+    "type": "hit"
+  },
+  {
+    "data": "cargo",
+    "index": 425,
+    "type": "upload"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "widget_map"
+    },
+    "index": 426,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "player"
+    },
+    "index": 427,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "location_valen-Bank"
+    },
+    "index": 428,
+    "type": "hit"
+  },
+  {
+    "data": "Bank",
+    "index": 429,
+    "type": "pilotAligned"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "widget_map"
+    },
+    "index": 430,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "widget_map"
+    },
+    "index": 431,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "thruster_action"
+    },
+    "index": 432,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 433,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 434,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 435,
+    "type": "hit"
+  },
+  {
+    "data": "Bank",
+    "index": 436,
+    "type": "docked"
+  },
+  {
+    "data": {
+      "event": "valen-key",
+      "from": "port",
+      "numberlessName": "console_line_#"
+    },
+    "index": 437,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "event": null,
+      "from": "port",
+      "numberlessName": "valen-Bank_slot_#"
+    },
+    "index": 438,
+    "type": "hit"
+  },
+  {
+    "data": "valen-Bank_slot_#",
+    "index": 439,
+    "type": "upload"
+  },
+  {
+    "data": {
+      "event": "loiqe-key",
+      "from": "port",
+      "numberlessName": "console_line_#"
+    },
+    "index": 440,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "event": null,
+      "from": "port",
+      "numberlessName": "valen-Bank_slot_#"
+    },
+    "index": 441,
+    "type": "hit"
+  },
+  {
+    "data": "valen-Bank_slot_#",
+    "index": 442,
+    "type": "upload"
+  },
+  {
+    "data": {
+      "event": "senni-key",
+      "from": "port",
+      "numberlessName": "console_line_#"
+    },
+    "index": 443,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "event": null,
+      "from": "port",
+      "numberlessName": "valen-Bank_slot_#"
+    },
+    "index": 444,
+    "type": "hit"
+  },
+  {
+    "data": "valen-Bank_slot_#",
+    "index": 445,
+    "type": "upload"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "location_valen-harvest"
+    },
+    "index": 446,
+    "type": "hit"
+  },
+  {
+    "data": "harvest",
+    "index": 447,
+    "type": "pilotAligned"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "thruster_action"
+    },
+    "index": 448,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 449,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 450,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 451,
+    "type": "hit"
+  },
+  {
+    "data": "harvest",
+    "index": 452,
+    "type": "docked"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "widget_radio"
+    },
+    "index": 453,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "mainpanel_cargo"
+    },
+    "index": 454,
+    "type": "hit"
+  },
+  {
+    "data": "cargo",
+    "index": 455,
+    "type": "upload"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "valen-harvest_ikov"
+    },
+    "index": 456,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "mainpanel_cargo"
+    },
+    "index": 457,
+    "type": "hit"
+  },
+  {
+    "data": "cargo",
+    "index": 458,
+    "type": "upload"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "widget_map"
+    },
+    "index": 459,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "player"
+    },
+    "index": 460,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "location_senni-Horadric"
+    },
+    "index": 461,
+    "type": "hit"
+  },
+  {
+    "data": "Horadric",
+    "index": 462,
+    "type": "pilotAligned"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "widget_map"
+    },
+    "index": 463,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "widget_map"
+    },
+    "index": 464,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "thruster_action"
+    },
+    "index": 465,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 466,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 467,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 468,
+    "type": "hit"
+  },
+  {
+    "data": "Horadric",
+    "index": 469,
+    "type": "docked"
+  },
+  {
+    "data": {
+      "event": "currency-2",
+      "from": "port",
+      "numberlessName": "console_line_#"
+    },
+    "index": 470,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "event": null,
+      "from": "port",
+      "numberlessName": "senni-Horadric_input_#"
+    },
+    "index": 471,
+    "type": "hit"
+  },
+  {
+    "data": "senni-Horadric_input_#",
+    "index": 472,
+    "type": "upload"
+  },
+  {
+    "data": {
+      "event": "currency-3",
+      "from": "port",
+      "numberlessName": "console_line_#"
+    },
+    "index": 473,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "event": null,
+      "from": "port",
+      "numberlessName": "senni-Horadric_input_#"
+    },
+    "index": 474,
+    "type": "hit"
+  },
+  {
+    "data": "ikeral",
+    "index": 475,
+    "type": "combination"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "senni-Horadric_output_1"
+    },
+    "index": 476,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "mainpanel_cargo"
+    },
+    "index": 477,
+    "type": "hit"
+  },
+  {
+    "data": "cargo",
+    "index": 478,
+    "type": "upload"
+  },
+  {
+    "data": {
+      "event": "record1",
+      "from": "port",
+      "numberlessName": "console_line_#"
+    },
+    "index": 479,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "event": null,
+      "from": "port",
+      "numberlessName": "senni-Horadric_input_#"
+    },
+    "index": 480,
+    "type": "hit"
+  },
+  {
+    "data": "senni-Horadric_input_#",
+    "index": 481,
+    "type": "upload"
+  },
+  {
+    "data": {
+      "event": "record2",
+      "from": "port",
+      "numberlessName": "console_line_#"
+    },
+    "index": 482,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "event": null,
+      "from": "port",
+      "numberlessName": "senni-Horadric_input_#"
+    },
+    "index": 483,
+    "type": "hit"
+  },
+  {
+    "data": "cassette",
+    "index": 484,
+    "type": "combination"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "senni-Horadric_output_1"
+    },
+    "index": 485,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "widget_radio"
+    },
+    "index": 486,
+    "type": "hit"
+  },
+  {
+    "data": "widget_radio",
+    "index": 487,
+    "type": "upload"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "widget_map"
+    },
+    "index": 488,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "player"
+    },
+    "index": 489,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "location_senni-fog"
+    },
+    "index": 490,
+    "type": "hit"
+  },
+  {
+    "data": "fog",
+    "index": 491,
+    "type": "pilotAligned"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "widget_map"
+    },
+    "index": 492,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "widget_map"
+    },
+    "index": 493,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "thruster_action"
+    },
+    "index": 494,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 495,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 496,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 497,
+    "type": "hit"
+  },
+  {
+    "data": "fog",
+    "index": 498,
+    "type": "docked"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "widget_map"
+    },
+    "index": 499,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "player"
+    },
+    "index": 500,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "location_valen-portal"
+    },
+    "index": 501,
+    "type": "hit"
+  },
+  {
+    "data": "portal",
+    "index": 502,
+    "type": "pilotAligned"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "widget_map"
+    },
+    "index": 503,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "widget_map"
+    },
+    "index": 504,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "thruster_action"
+    },
+    "index": 505,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 506,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 507,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 508,
+    "type": "hit"
+  },
+  {
+    "data": "portal",
+    "index": 509,
+    "type": "docked"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "widget_map"
+    },
+    "index": 510,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "player"
+    },
+    "index": 511,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "location_loiqe-portal"
+    },
+    "index": 512,
+    "type": "hit"
+  },
+  {
+    "data": "portal",
+    "index": 513,
+    "type": "pilotAligned"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "widget_map"
+    },
+    "index": 514,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "widget_map"
+    },
+    "index": 515,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "thruster_action"
+    },
+    "index": 516,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 517,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 518,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 519,
+    "type": "hit"
+  },
+  {
+    "data": "portal",
+    "index": 520,
+    "type": "docked"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "widget_map"
+    },
+    "index": 521,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "player"
+    },
+    "index": 522,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "location_loiqe-fog"
+    },
+    "index": 523,
+    "type": "hit"
+  },
+  {
+    "data": "fog",
+    "index": 524,
+    "type": "pilotAligned"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "widget_map"
+    },
+    "index": 525,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "widget_map"
+    },
+    "index": 526,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "thruster_action"
+    },
+    "index": 527,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 528,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 529,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 530,
+    "type": "hit"
+  },
+  {
+    "data": "fog",
+    "index": 531,
+    "type": "docked"
+  },
+  {
+    "data": {
+      "event": "currency-5",
+      "from": "port",
+      "numberlessName": "console_line_#"
+    },
+    "index": 532,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "loiqe-fog_want"
+    },
+    "index": 533,
+    "type": "hit"
+  },
+  {
+    "data": "loiqe-fog_want",
+    "index": 534,
+    "type": "upload"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "loiqe-fog_give"
+    },
+    "index": 535,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "mainpanel_cargo"
+    },
+    "index": 536,
+    "type": "hit"
+  },
+  {
+    "data": "cargo",
+    "index": 537,
+    "type": "upload"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "widget_map"
+    },
+    "index": 538,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "player"
+    },
+    "index": 539,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "location_loiqe-portal"
+    },
+    "index": 540,
+    "type": "hit"
+  },
+  {
+    "data": "portal",
+    "index": 541,
+    "type": "pilotAligned"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "widget_map"
+    },
+    "index": 542,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "widget_map"
+    },
+    "index": 543,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "thruster_action"
+    },
+    "index": 544,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 545,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 546,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 547,
+    "type": "hit"
+  },
+  {
+    "data": "portal",
+    "index": 548,
+    "type": "docked"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "widget_map"
+    },
+    "index": 549,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "player"
+    },
+    "index": 550,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "location_loiqe-Horadric"
+    },
+    "index": 551,
+    "type": "hit"
+  },
+  {
+    "data": "Horadric",
+    "index": 552,
+    "type": "pilotAligned"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "widget_map"
+    },
+    "index": 553,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "widget_map"
+    },
+    "index": 554,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "thruster_action"
+    },
+    "index": 555,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 556,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 557,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 558,
+    "type": "hit"
+  },
+  {
+    "data": "Horadric",
+    "index": 559,
+    "type": "docked"
+  },
+  {
+    "data": {
+      "event": "usul-key-1",
+      "from": "port",
+      "numberlessName": "console_line_#"
+    },
+    "index": 560,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "event": null,
+      "from": "port",
+      "numberlessName": "loiqe-Horadric_input_#"
+    },
+    "index": 561,
+    "type": "hit"
+  },
+  {
+    "data": "loiqe-Horadric_input_#",
+    "index": 562,
+    "type": "upload"
+  },
+  {
+    "data": {
+      "event": "usul-key-2",
+      "from": "port",
+      "numberlessName": "console_line_#"
+    },
+    "index": 563,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "event": null,
+      "from": "port",
+      "numberlessName": "loiqe-Horadric_input_#"
+    },
+    "index": 564,
+    "type": "hit"
+  },
+  {
+    "data": "usul key",
+    "index": 565,
+    "type": "combination"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "loiqe-Horadric_output_1"
+    },
+    "index": 566,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "mainpanel_cargo"
+    },
+    "index": 567,
+    "type": "hit"
+  },
+  {
+    "data": "cargo",
+    "index": 568,
+    "type": "upload"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "widget_radio"
+    },
+    "index": 569,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "mainpanel_cargo"
+    },
+    "index": 570,
+    "type": "hit"
+  },
+  {
+    "data": "cargo",
+    "index": 571,
+    "type": "upload"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "widget_map"
+    },
+    "index": 572,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "player"
+    },
+    "index": 573,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "location_loiqe-portal"
+    },
+    "index": 574,
+    "type": "hit"
+  },
+  {
+    "data": "portal",
+    "index": 575,
+    "type": "pilotAligned"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "widget_map"
+    },
+    "index": 576,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "widget_map"
+    },
+    "index": 577,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "thruster_action"
+    },
+    "index": 578,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 579,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 580,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 581,
+    "type": "hit"
+  },
+  {
+    "data": "portal",
+    "index": 582,
+    "type": "docked"
+  },
+  {
+    "data": {
+      "event": "usul-key",
+      "from": "port",
+      "numberlessName": "console_line_#"
+    },
+    "index": 583,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "mainpanel_mission"
+    },
+    "index": 584,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "loiqe-portal_thruster"
+    },
+    "index": 585,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "mainpanel_thruster"
+    },
+    "index": 586,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "mainpanel_radar"
+    },
+    "index": 587,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "mainpanel_radar"
+    },
+    "index": 588,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "loiqe-portal_pilot"
+    },
+    "index": 589,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "mainpanel_pilot"
+    },
+    "index": 590,
+    "type": "hit"
+  },
+  {
+    "data": "portal",
+    "index": 591,
+    "type": "pilotAligned"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "thruster_action"
+    },
+    "index": 592,
+    "type": "hit"
+  },
+  {
+    "data": "portal",
+    "index": 593,
+    "type": "docked"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "mainpanel_radar"
+    },
+    "index": 594,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "mainpanel_pilot"
+    },
+    "index": 595,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "location_usul-station"
+    },
+    "index": 596,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "thruster_action"
+    },
+    "index": 597,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 598,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 599,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 600,
+    "type": "hit"
+  },
+  {
+    "data": "station",
+    "index": 601,
+    "type": "docked"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "widget_map"
+    },
+    "index": 602,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "player"
+    },
+    "index": 603,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "location_senni-transit"
+    },
+    "index": 604,
+    "type": "hit"
+  },
+  {
+    "data": "transit",
+    "index": 605,
+    "type": "pilotAligned"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "widget_map"
+    },
+    "index": 606,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "widget_map"
+    },
+    "index": 607,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "thruster_action"
+    },
+    "index": 608,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 609,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 610,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 611,
+    "type": "hit"
+  },
+  {
+    "data": "transit",
+    "index": 612,
+    "type": "docked"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "widget_map"
+    },
+    "index": 613,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "player"
+    },
+    "index": 614,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "location_valen-Bank"
+    },
+    "index": 615,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "widget_map"
+    },
+    "index": 616,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "widget_map"
+    },
+    "index": 617,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "thruster_action"
+    },
+    "index": 618,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 619,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 620,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 621,
+    "type": "hit"
+  },
+  {
+    "data": "Bank",
+    "index": 622,
+    "type": "docked"
+  },
+  {
+    "data": {
+      "event": "record3",
+      "from": "port",
+      "numberlessName": "console_line_#"
+    },
+    "index": 623,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "event": null,
+      "from": "port",
+      "numberlessName": "valen-Bank_slot_#"
+    },
+    "index": 624,
+    "type": "hit"
+  },
+  {
+    "data": "valen-Bank_slot_#",
+    "index": 625,
+    "type": "upload"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "location_valen-harvest"
+    },
+    "index": 626,
+    "type": "hit"
+  },
+  {
+    "data": "harvest",
+    "index": 627,
+    "type": "pilotAligned"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "thruster_action"
+    },
+    "index": 628,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 629,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 630,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 631,
+    "type": "hit"
+  },
+  {
+    "data": "harvest",
+    "index": 632,
+    "type": "docked"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "valen-harvest_ikov"
+    },
+    "index": 633,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "mainpanel_cargo"
+    },
+    "index": 634,
+    "type": "hit"
+  },
+  {
+    "data": "cargo",
+    "index": 635,
+    "type": "upload"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "widget_map"
+    },
+    "index": 636,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "player"
+    },
+    "index": 637,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "location_senni-harvest"
+    },
+    "index": 638,
+    "type": "hit"
+  },
+  {
+    "data": "harvest",
+    "index": 639,
+    "type": "pilotAligned"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "widget_map"
+    },
+    "index": 640,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "widget_map"
+    },
+    "index": 641,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "thruster_action"
+    },
+    "index": 642,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 643,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 644,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 645,
+    "type": "hit"
+  },
+  {
+    "data": "harvest",
+    "index": 646,
+    "type": "docked"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "senni-harvest_eral"
+    },
+    "index": 647,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "mainpanel_cargo"
+    },
+    "index": 648,
+    "type": "hit"
+  },
+  {
+    "data": "cargo",
+    "index": 649,
+    "type": "upload"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "location_senni-Horadric"
+    },
+    "index": 650,
+    "type": "hit"
+  },
+  {
+    "data": "Horadric",
+    "index": 651,
+    "type": "pilotAligned"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "thruster_action"
+    },
+    "index": 652,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 653,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 654,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 655,
+    "type": "hit"
+  },
+  {
+    "data": "Horadric",
+    "index": 656,
+    "type": "docked"
+  },
+  {
+    "data": {
+      "event": "currency-2",
+      "from": "port",
+      "numberlessName": "console_line_#"
+    },
+    "index": 657,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "event": null,
+      "from": "port",
+      "numberlessName": "senni-Horadric_input_#"
+    },
+    "index": 658,
+    "type": "hit"
+  },
+  {
+    "data": "senni-Horadric_input_#",
+    "index": 659,
+    "type": "upload"
+  },
+  {
+    "data": {
+      "event": "currency-3",
+      "from": "port",
+      "numberlessName": "console_line_#"
+    },
+    "index": 660,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "event": null,
+      "from": "port",
+      "numberlessName": "senni-Horadric_input_#"
+    },
+    "index": 661,
+    "type": "hit"
+  },
+  {
+    "data": "ikeral",
+    "index": 662,
+    "type": "combination"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "senni-Horadric_output_1"
+    },
+    "index": 663,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "mainpanel_cargo"
+    },
+    "index": 664,
+    "type": "hit"
+  },
+  {
+    "data": "cargo",
+    "index": 665,
+    "type": "upload"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "widget_map"
+    },
+    "index": 666,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "player"
+    },
+    "index": 667,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "location_senni-wreck"
+    },
+    "index": 668,
+    "type": "hit"
+  },
+  {
+    "data": "wreck",
+    "index": 669,
+    "type": "pilotAligned"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "widget_map"
+    },
+    "index": 670,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "widget_map"
+    },
+    "index": 671,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "thruster_action"
+    },
+    "index": 672,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 673,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 674,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 675,
+    "type": "hit"
+  },
+  {
+    "data": "wreck",
+    "index": 676,
+    "type": "docked"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "widget_map"
+    },
+    "index": 677,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "player"
+    },
+    "index": 678,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "location_usul-station"
+    },
+    "index": 679,
+    "type": "hit"
+  },
+  {
+    "data": "station",
+    "index": 680,
+    "type": "pilotAligned"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "widget_map"
+    },
+    "index": 681,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "widget_map"
+    },
+    "index": 682,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "thruster_action"
+    },
+    "index": 683,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 684,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 685,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 686,
+    "type": "hit"
+  },
+  {
+    "data": "station",
+    "index": 687,
+    "type": "docked"
+  },
+  {
+    "data": {
+      "event": "currency-5",
+      "from": "port",
+      "numberlessName": "console_line_#"
+    },
+    "index": 688,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "usul-station"
+    },
+    "index": 689,
+    "type": "hit"
+  },
+  {
+    "data": "usul-station",
+    "index": 690,
+    "type": "upload"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "button_usul-station_install"
+    },
+    "index": 691,
+    "type": "hit"
+  },
+  {
+    "data": 15,
+    "index": 692,
+    "skip": true,
+    "type": "mission"
+  },
+  {
+    "data": 0,
+    "index": 693,
+    "type": "playerUnlock"
+  },
+  {
+    "data": {
+      "event": "battery-3",
+      "from": "port",
+      "numberlessName": "battery_slot_cell#"
+    },
+    "index": 694,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "battery_slot_oxygen"
+    },
+    "index": 695,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "widget_map"
+    },
+    "index": 696,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "player"
+    },
+    "index": 697,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "location_valen-Bank"
+    },
+    "index": 698,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "widget_map"
+    },
+    "index": 699,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "widget_map"
+    },
+    "index": 700,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "thruster_action"
+    },
+    "index": 701,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 702,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 703,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 704,
+    "type": "hit"
+  },
+  {
+    "data": "Bank",
+    "index": 705,
+    "type": "docked"
+  },
+  {
+    "data": {
+      "event": "valen-key",
+      "from": "port",
+      "numberlessName": "valen-Bank_slot_#"
+    },
+    "index": 706,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "mainpanel_cargo"
+    },
+    "index": 707,
+    "type": "hit"
+  },
+  {
+    "data": "cargo",
+    "index": 708,
+    "type": "upload"
+  },
+  {
+    "data": {
+      "event": "loiqe-key",
+      "from": "port",
+      "numberlessName": "valen-Bank_slot_#"
+    },
+    "index": 709,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "mainpanel_cargo"
+    },
+    "index": 710,
+    "type": "hit"
+  },
+  {
+    "data": "cargo",
+    "index": 711,
+    "type": "upload"
+  },
+  {
+    "data": {
+      "event": "senni-key",
+      "from": "port",
+      "numberlessName": "valen-Bank_slot_#"
+    },
+    "index": 712,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "mainpanel_cargo"
+    },
+    "index": 713,
+    "type": "hit"
+  },
+  {
+    "data": "cargo",
+    "index": 714,
+    "type": "upload"
+  },
+  {
+    "data": {
+      "event": "record3",
+      "from": "port",
+      "numberlessName": "valen-Bank_slot_#"
+    },
+    "index": 715,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "mainpanel_cargo"
+    },
+    "index": 716,
+    "type": "hit"
+  },
+  {
+    "data": "cargo",
+    "index": 717,
+    "type": "upload"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "widget_map"
+    },
+    "index": 718,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "player"
+    },
+    "index": 719,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "location_senni-Horadric"
+    },
+    "index": 720,
+    "type": "hit"
+  },
+  {
+    "data": "Horadric",
+    "index": 721,
+    "type": "pilotAligned"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "widget_map"
+    },
+    "index": 722,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "widget_map"
+    },
+    "index": 723,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "thruster_action"
+    },
+    "index": 724,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 725,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 726,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 727,
+    "type": "hit"
+  },
+  {
+    "data": "Horadric",
+    "index": 728,
+    "type": "docked"
+  },
+  {
+    "data": {
+      "event": "usul-key",
+      "from": "port",
+      "numberlessName": "console_line_#"
+    },
+    "index": 729,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "event": null,
+      "from": "port",
+      "numberlessName": "senni-Horadric_input_#"
+    },
+    "index": 730,
+    "type": "hit"
+  },
+  {
+    "data": "senni-Horadric_input_#",
+    "index": 731,
+    "type": "upload"
+  },
+  {
+    "data": {
+      "event": "valen-key",
+      "from": "port",
+      "numberlessName": "console_line_#"
+    },
+    "index": 732,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "event": null,
+      "from": "port",
+      "numberlessName": "senni-Horadric_input_#"
+    },
+    "index": 733,
+    "type": "hit"
+  },
+  {
+    "data": "horizontal part",
+    "index": 734,
+    "type": "combination"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "senni-Horadric_output_1"
+    },
+    "index": 735,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "mainpanel_cargo"
+    },
+    "index": 736,
+    "type": "hit"
+  },
+  {
+    "data": "cargo",
+    "index": 737,
+    "type": "upload"
+  },
+  {
+    "data": {
+      "event": "loiqe-key",
+      "from": "port",
+      "numberlessName": "console_line_#"
+    },
+    "index": 738,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "event": null,
+      "from": "port",
+      "numberlessName": "senni-Horadric_input_#"
+    },
+    "index": 739,
+    "type": "hit"
+  },
+  {
+    "data": "senni-Horadric_input_#",
+    "index": 740,
+    "type": "upload"
+  },
+  {
+    "data": {
+      "event": "senni-key",
+      "from": "port",
+      "numberlessName": "console_line_#"
+    },
+    "index": 741,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "event": null,
+      "from": "port",
+      "numberlessName": "senni-Horadric_input_#"
+    },
+    "index": 742,
+    "type": "hit"
+  },
+  {
+    "data": "vertical part",
+    "index": 743,
+    "type": "combination"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "senni-Horadric_output_1"
+    },
+    "index": 744,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "mainpanel_cargo"
+    },
+    "index": 745,
+    "type": "hit"
+  },
+  {
+    "data": "cargo",
+    "index": 746,
+    "type": "upload"
+  },
+  {
+    "data": {
+      "event": "end-key-1",
+      "from": "port",
+      "numberlessName": "console_line_#"
+    },
+    "index": 747,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "event": null,
+      "from": "port",
+      "numberlessName": "senni-Horadric_input_#"
+    },
+    "index": 748,
+    "type": "hit"
+  },
+  {
+    "data": "senni-Horadric_input_#",
+    "index": 749,
+    "type": "upload"
+  },
+  {
+    "data": {
+      "event": "end-key-2",
+      "from": "port",
+      "numberlessName": "console_line_#"
+    },
+    "index": 750,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "event": null,
+      "from": "port",
+      "numberlessName": "senni-Horadric_input_#"
+    },
+    "index": 751,
+    "type": "hit"
+  },
+  {
+    "data": "End Key",
+    "index": 752,
+    "type": "combination"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "senni-Horadric_output_1"
+    },
+    "index": 753,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "mainpanel_cargo"
+    },
+    "index": 754,
+    "type": "hit"
+  },
+  {
+    "data": "cargo",
+    "index": 755,
+    "type": "upload"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "widget_map"
+    },
+    "index": 756,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "player"
+    },
+    "index": 757,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "location_senni-wreck"
+    },
+    "index": 758,
+    "type": "hit"
+  },
+  {
+    "data": "wreck",
+    "index": 759,
+    "type": "pilotAligned"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "widget_map"
+    },
+    "index": 760,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "widget_map"
+    },
+    "index": 761,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "thruster_action"
+    },
+    "index": 762,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 763,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 764,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 765,
+    "type": "hit"
+  },
+  {
+    "data": "wreck",
+    "index": 766,
+    "type": "docked"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "widget_map"
+    },
+    "index": 767,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "player"
+    },
+    "index": 768,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "location_usul-station"
+    },
+    "index": 769,
+    "type": "hit"
+  },
+  {
+    "data": "station",
+    "index": 770,
+    "type": "pilotAligned"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "widget_map"
+    },
+    "index": 771,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "widget_map"
+    },
+    "index": 772,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "thruster_action"
+    },
+    "index": 773,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 774,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 775,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 776,
+    "type": "hit"
+  },
+  {
+    "data": "station",
+    "index": 777,
+    "type": "docked"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "location_usul-portal"
+    },
+    "index": 778,
+    "type": "hit"
+  },
+  {
+    "data": "portal",
+    "index": 779,
+    "type": "pilotAligned"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "thruster_action"
+    },
+    "index": 780,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 781,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 782,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 783,
+    "type": "hit"
+  },
+  {
+    "data": "portal",
+    "index": 784,
+    "type": "docked"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "location_usul-telescope"
+    },
+    "index": 785,
+    "type": "hit"
+  },
+  {
+    "data": "telescope",
+    "index": 786,
+    "type": "pilotAligned"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "thruster_action"
+    },
+    "index": 787,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 788,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 789,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 790,
+    "type": "hit"
+  },
+  {
+    "data": "telescope",
+    "index": 791,
+    "type": "docked"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "widget_map"
+    },
+    "index": 792,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "mainpanel_cargo"
+    },
+    "index": 793,
+    "type": "hit"
+  },
+  {
+    "data": "cargo",
+    "index": 794,
+    "type": "upload"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "usul-telescope_Blind Map"
+    },
+    "index": 795,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "widget_map"
+    },
+    "index": 796,
+    "type": "hit"
+  },
+  {
+    "data": "widget_map",
+    "index": 797,
+    "type": "upload"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "location_usul-silence"
+    },
+    "index": 798,
+    "type": "hit"
+  },
+  {
+    "data": "silence",
+    "index": 799,
+    "type": "pilotAligned"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "thruster_action"
+    },
+    "index": 800,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 801,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 802,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 803,
+    "type": "hit"
+  },
+  {
+    "data": "silence",
+    "index": 804,
+    "type": "docked"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "location_usul-annex"
+    },
+    "index": 805,
+    "type": "hit"
+  },
+  {
+    "data": "annex",
+    "index": 806,
+    "type": "pilotAligned"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "thruster_action"
+    },
+    "index": 807,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 808,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 809,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 810,
+    "type": "hit"
+  },
+  {
+    "data": "annex",
+    "index": 811,
+    "type": "docked"
+  },
+  {
+    "data": {
+      "event": "battery-3",
+      "from": "port",
+      "numberlessName": "battery_slot_cell#"
+    },
+    "index": 812,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "battery_slot_radio"
+    },
+    "index": 813,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "usul-annex_drive"
+    },
+    "index": 814,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "widget_radio"
+    },
+    "index": 815,
+    "type": "hit"
+  },
+  {
+    "data": "widget_radio",
+    "index": 816,
+    "type": "upload"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "widget_map"
+    },
+    "index": 817,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "mainpanel_cargo"
+    },
+    "index": 818,
+    "type": "hit"
+  },
+  {
+    "data": "cargo",
+    "index": 819,
+    "type": "upload"
+  },
+  {
+    "data": {
+      "event": "map-1",
+      "from": "port",
+      "numberlessName": "console_line_#"
+    },
+    "index": 820,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "widget_map"
+    },
+    "index": 821,
+    "type": "hit"
+  },
+  {
+    "data": "widget_map",
+    "index": 822,
+    "type": "upload"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "widget_map"
+    },
+    "index": 823,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "player"
+    },
+    "index": 824,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "location_senni-transit"
+    },
+    "index": 825,
+    "type": "hit"
+  },
+  {
+    "data": "transit",
+    "index": 826,
+    "type": "pilotAligned"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "widget_map"
+    },
+    "index": 827,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "widget_map"
+    },
+    "index": 828,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "thruster_action"
+    },
+    "index": 829,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 830,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 831,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 832,
+    "type": "hit"
+  },
+  {
+    "data": "transit",
+    "index": 833,
+    "type": "docked"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "widget_map"
+    },
+    "index": 834,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "player"
+    },
+    "index": 835,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "location_valen-Bank"
+    },
+    "index": 836,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "widget_map"
+    },
+    "index": 837,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "widget_map"
+    },
+    "index": 838,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "thruster_action"
+    },
+    "index": 839,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 840,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 841,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 842,
+    "type": "hit"
+  },
+  {
+    "data": "Bank",
+    "index": 843,
+    "type": "docked"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "location_valen-harvest"
+    },
+    "index": 844,
+    "type": "hit"
+  },
+  {
+    "data": "harvest",
+    "index": 845,
+    "type": "pilotAligned"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "thruster_action"
+    },
+    "index": 846,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 847,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 848,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 849,
+    "type": "hit"
+  },
+  {
+    "data": "harvest",
+    "index": 850,
+    "type": "docked"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "valen-harvest_ikov"
+    },
+    "index": 851,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "mainpanel_cargo"
+    },
+    "index": 852,
+    "type": "hit"
+  },
+  {
+    "data": "cargo",
+    "index": 853,
+    "type": "upload"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "widget_map"
+    },
+    "index": 854,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "player"
+    },
+    "index": 855,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "location_senni-harvest"
+    },
+    "index": 856,
+    "type": "hit"
+  },
+  {
+    "data": "harvest",
+    "index": 857,
+    "type": "pilotAligned"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "widget_map"
+    },
+    "index": 858,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "widget_map"
+    },
+    "index": 859,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "thruster_action"
+    },
+    "index": 860,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 861,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 862,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 863,
+    "type": "hit"
+  },
+  {
+    "data": "harvest",
+    "index": 864,
+    "type": "docked"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "senni-harvest_eral"
+    },
+    "index": 865,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "mainpanel_cargo"
+    },
+    "index": 866,
+    "type": "hit"
+  },
+  {
+    "data": "cargo",
+    "index": 867,
+    "type": "upload"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "location_senni-Horadric"
+    },
+    "index": 868,
+    "type": "hit"
+  },
+  {
+    "data": "Horadric",
+    "index": 869,
+    "type": "pilotAligned"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "thruster_action"
+    },
+    "index": 870,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 871,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 872,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 873,
+    "type": "hit"
+  },
+  {
+    "data": "Horadric",
+    "index": 874,
+    "type": "docked"
+  },
+  {
+    "data": {
+      "event": "currency-2",
+      "from": "port",
+      "numberlessName": "console_line_#"
+    },
+    "index": 875,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "event": null,
+      "from": "port",
+      "numberlessName": "senni-Horadric_input_#"
+    },
+    "index": 876,
+    "type": "hit"
+  },
+  {
+    "data": "senni-Horadric_input_#",
+    "index": 877,
+    "type": "upload"
+  },
+  {
+    "data": {
+      "event": "currency-3",
+      "from": "port",
+      "numberlessName": "console_line_#"
+    },
+    "index": 878,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "event": null,
+      "from": "port",
+      "numberlessName": "senni-Horadric_input_#"
+    },
+    "index": 879,
+    "type": "hit"
+  },
+  {
+    "data": "ikeral",
+    "index": 880,
+    "type": "combination"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "senni-Horadric_output_1"
+    },
+    "index": 881,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "mainpanel_cargo"
+    },
+    "index": 882,
+    "type": "hit"
+  },
+  {
+    "data": "cargo",
+    "index": 883,
+    "type": "upload"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "widget_map"
+    },
+    "index": 884,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "player"
+    },
+    "index": 885,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "location_valen-harvest"
+    },
+    "index": 886,
+    "type": "hit"
+  },
+  {
+    "data": "harvest",
+    "index": 887,
+    "type": "pilotAligned"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "widget_map"
+    },
+    "index": 888,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "widget_map"
+    },
+    "index": 889,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "thruster_action"
+    },
+    "index": 890,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 891,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 892,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 893,
+    "type": "hit"
+  },
+  {
+    "data": "currency-2",
+    "index": 894,
+    "type": "harvest"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "valen-harvest_ikov"
+    },
+    "index": 895,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "mainpanel_cargo"
+    },
+    "index": 896,
+    "type": "hit"
+  },
+  {
+    "data": "cargo",
+    "index": 897,
+    "type": "upload"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "widget_map"
+    },
+    "index": 898,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "player"
+    },
+    "index": 899,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "location_loiqe-portal"
+    },
+    "index": 900,
+    "type": "hit"
+  },
+  {
+    "data": "portal",
+    "index": 901,
+    "type": "pilotAligned"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "widget_map"
+    },
+    "index": 902,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "widget_map"
+    },
+    "index": 903,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "thruster_action"
+    },
+    "index": 904,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 905,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 906,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 907,
+    "type": "hit"
+  },
+  {
+    "data": "portal",
+    "index": 908,
+    "type": "docked"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "widget_map"
+    },
+    "index": 909,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "player"
+    },
+    "index": 910,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "location_loiqe-port"
+    },
+    "index": 911,
+    "type": "hit"
+  },
+  {
+    "data": "port",
+    "index": 912,
+    "type": "pilotAligned"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "widget_map"
+    },
+    "index": 913,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "widget_map"
+    },
+    "index": 914,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "thruster_action"
+    },
+    "index": 915,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 916,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 917,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 918,
+    "type": "hit"
+  },
+  {
+    "data": "port",
+    "index": 919,
+    "type": "docked"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "widget_map"
+    },
+    "index": 920,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "player"
+    },
+    "index": 921,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "location_loiqe-Harvest"
+    },
+    "index": 922,
+    "type": "hit"
+  },
+  {
+    "data": "Harvest",
+    "index": 923,
+    "type": "pilotAligned"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "widget_map"
+    },
+    "index": 924,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "widget_map"
+    },
+    "index": 925,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 926,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 927,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 928,
+    "type": "hit"
+  },
+  {
+    "data": "Harvest",
+    "index": 929,
+    "type": "docked"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "loiqe-Harvest_alta"
+    },
+    "index": 930,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "mainpanel_cargo"
+    },
+    "index": 931,
+    "type": "hit"
+  },
+  {
+    "data": "cargo",
+    "index": 932,
+    "type": "upload"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "widget_map"
+    },
+    "index": 933,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "player"
+    },
+    "index": 934,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "location_loiqe-Horadric"
+    },
+    "index": 935,
+    "type": "hit"
+  },
+  {
+    "data": "Horadric",
+    "index": 936,
+    "type": "pilotAligned"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "widget_map"
+    },
+    "index": 937,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "widget_map"
+    },
+    "index": 938,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "thruster_action"
+    },
+    "index": 939,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 940,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 941,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 942,
+    "type": "hit"
+  },
+  {
+    "data": "Horadric",
+    "index": 943,
+    "type": "docked"
+  },
+  {
+    "data": {
+      "event": "currency-1",
+      "from": "port",
+      "numberlessName": "console_line_#"
+    },
+    "index": 944,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "event": null,
+      "from": "port",
+      "numberlessName": "loiqe-Horadric_input_#"
+    },
+    "index": 945,
+    "type": "hit"
+  },
+  {
+    "data": "loiqe-Horadric_input_#",
+    "index": 946,
+    "type": "upload"
+  },
+  {
+    "data": {
+      "event": "currency-2",
+      "from": "port",
+      "numberlessName": "console_line_#"
+    },
+    "index": 947,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "event": null,
+      "from": "port",
+      "numberlessName": "loiqe-Horadric_input_#"
+    },
+    "index": 948,
+    "type": "hit"
+  },
+  {
+    "data": "altiov",
+    "index": 949,
+    "type": "combination"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "loiqe-Horadric_output_1"
+    },
+    "index": 950,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "mainpanel_cargo"
+    },
+    "index": 951,
+    "type": "hit"
+  },
+  {
+    "data": "cargo",
+    "index": 952,
+    "type": "upload"
+  },
+  {
+    "data": {
+      "event": "currency-4",
+      "from": "port",
+      "numberlessName": "console_line_#"
+    },
+    "index": 953,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "event": null,
+      "from": "port",
+      "numberlessName": "loiqe-Horadric_input_#"
+    },
+    "index": 954,
+    "type": "hit"
+  },
+  {
+    "data": "loiqe-Horadric_input_#",
+    "index": 955,
+    "type": "upload"
+  },
+  {
+    "data": {
+      "event": "currency-5",
+      "from": "port",
+      "numberlessName": "console_line_#"
+    },
+    "index": 956,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "event": null,
+      "from": "port",
+      "numberlessName": "loiqe-Horadric_input_#"
+    },
+    "index": 957,
+    "type": "hit"
+  },
+  {
+    "data": "echo",
+    "index": 958,
+    "type": "combination"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "loiqe-Horadric_output_1"
+    },
+    "index": 959,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "mainpanel_cargo"
+    },
+    "index": 960,
+    "type": "hit"
+  },
+  {
+    "data": "cargo",
+    "index": 961,
+    "type": "upload"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "widget_map"
+    },
+    "index": 962,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "player"
+    },
+    "index": 963,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "location_usul-station"
+    },
+    "index": 964,
+    "type": "hit"
+  },
+  {
+    "data": "station",
+    "index": 965,
+    "type": "pilotAligned"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "widget_map"
+    },
+    "index": 966,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "widget_map"
+    },
+    "index": 967,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "thruster_action"
+    },
+    "index": 968,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 969,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 970,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 971,
+    "type": "hit"
+  },
+  {
+    "data": "station",
+    "index": 972,
+    "type": "docked"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "widget_map"
+    },
+    "index": 973,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "mainpanel_cargo"
+    },
+    "index": 974,
+    "type": "hit"
+  },
+  {
+    "data": "cargo",
+    "index": 975,
+    "type": "upload"
+  },
+  {
+    "data": {
+      "event": "map-2",
+      "from": "port",
+      "numberlessName": "console_line_#"
+    },
+    "index": 976,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "widget_map"
+    },
+    "index": 977,
+    "type": "hit"
+  },
+  {
+    "data": "widget_map",
+    "index": 978,
+    "type": "upload"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "location_usul-silence"
+    },
+    "index": 979,
+    "type": "hit"
+  },
+  {
+    "data": "silence",
+    "index": 980,
+    "type": "pilotAligned"
+  },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": {
+      "from": "trigger",
+      "name": "thruster_action"
+    },
+    "index": 981,
+    "type": "hit"
   },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 982,
+    "type": "hit"
   },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 983,
+    "type": "hit"
   },
-  { "type": "docked", "data": "portal" },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "location_usul-telescope" }
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 984,
+    "type": "hit"
   },
-  { "type": "pilotAligned", "data": "telescope" },
-  { "type": "hit", "data": { "from": "trigger", "name": "thruster_action" } },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": "silence",
+    "index": 985,
+    "type": "docked"
   },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": {
+      "event": "currency-6",
+      "from": "port",
+      "numberlessName": "console_line_#"
+    },
+    "index": 986,
+    "type": "hit"
   },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": {
+      "from": "port",
+      "name": "usul-silence_want"
+    },
+    "index": 987,
+    "type": "hit"
   },
-  { "type": "docked", "data": "telescope" },
-  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
-  { "type": "hit", "data": { "from": "port", "name": "mainpanel_cargo" } },
-  { "type": "upload", "data": "cargo" },
   {
-    "type": "hit",
-    "data": { "from": "port", "name": "usul-telescope_Blind Map" }
+    "data": "usul-silence_want",
+    "index": 988,
+    "type": "upload"
   },
-  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
-  { "type": "upload", "data": "widget_map" },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "location_usul-silence" }
+    "data": {
+      "from": "port",
+      "name": "usul-silence_give"
+    },
+    "index": 989,
+    "type": "hit"
   },
-  { "type": "pilotAligned", "data": "silence" },
-  { "type": "hit", "data": { "from": "trigger", "name": "thruster_action" } },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": {
+      "from": "port",
+      "name": "mainpanel_cargo"
+    },
+    "index": 990,
+    "type": "hit"
   },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": "cargo",
+    "index": 991,
+    "type": "upload"
   },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": {
+      "from": "port",
+      "name": "widget_radio"
+    },
+    "index": 992,
+    "type": "hit"
   },
-  { "type": "docked", "data": "silence" },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "location_usul-annex" }
+    "data": {
+      "from": "port",
+      "name": "mainpanel_cargo"
+    },
+    "index": 993,
+    "type": "hit"
   },
-  { "type": "pilotAligned", "data": "annex" },
-  { "type": "hit", "data": { "from": "trigger", "name": "thruster_action" } },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": "cargo",
+    "index": 994,
+    "type": "upload"
   },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": {
+      "event": "battery-3",
+      "from": "port",
+      "numberlessName": "battery_slot_cell#"
+    },
+    "index": 995,
+    "type": "hit"
   },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": {
+      "from": "port",
+      "name": "battery_slot_oxygen"
+    },
+    "index": 996,
+    "type": "hit"
   },
-  { "type": "docked", "data": "annex" },
   {
-    "type": "hit",
     "data": {
+      "event": "shield-1",
       "from": "port",
-      "numberlessName": "battery_slot_cell#",
-      "event": "battery-3"
-    }
+      "numberlessName": "console_line_#"
+    },
+    "index": 997,
+    "type": "hit"
   },
-  { "type": "hit", "data": { "from": "port", "name": "battery_slot_radio" } },
-  { "type": "hit", "data": { "from": "port", "name": "usul-annex_drive" } },
-  { "type": "hit", "data": { "from": "port", "name": "widget_radio" } },
-  { "type": "upload", "data": "widget_radio" },
-  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
-  { "type": "hit", "data": { "from": "port", "name": "mainpanel_cargo" } },
-  { "type": "upload", "data": "cargo" },
   {
-    "type": "hit",
     "data": {
       "from": "port",
-      "numberlessName": "console_line_#",
-      "event": "map-1"
-    }
+      "name": "widget_shield"
+    },
+    "index": 998,
+    "type": "hit"
   },
-  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
-  { "type": "upload", "data": "widget_map" },
-  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
-  { "type": "hit", "data": { "from": "port", "name": "player" } },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "location_senni-transit" }
+    "data": 17,
+    "index": 999,
+    "skip": true,
+    "type": "mission"
   },
-  { "type": "pilotAligned", "data": "transit" },
-  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
-  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
-  { "type": "hit", "data": { "from": "trigger", "name": "thruster_action" } },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": "widget_shield",
+    "index": 1000,
+    "type": "upload"
   },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": {
+      "from": "port",
+      "name": "widget_map"
+    },
+    "index": 1001,
+    "type": "hit"
   },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": {
+      "from": "port",
+      "name": "player"
+    },
+    "index": 1002,
+    "type": "hit"
   },
-  { "type": "docked", "data": "transit" },
-  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
-  { "type": "hit", "data": { "from": "port", "name": "player" } },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "location_valen-Bank" }
+    "data": {
+      "from": "trigger",
+      "name": "location_loiqe-portal"
+    },
+    "index": 1003,
+    "type": "hit"
   },
-  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
-  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
-  { "type": "hit", "data": { "from": "trigger", "name": "thruster_action" } },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": "portal",
+    "index": 1004,
+    "type": "pilotAligned"
   },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": {
+      "from": "port",
+      "name": "widget_map"
+    },
+    "index": 1005,
+    "type": "hit"
   },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": {
+      "from": "port",
+      "name": "widget_map"
+    },
+    "index": 1006,
+    "type": "hit"
   },
-  { "type": "docked", "data": "Bank" },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "location_valen-harvest" }
+    "data": {
+      "from": "trigger",
+      "name": "thruster_action"
+    },
+    "index": 1007,
+    "type": "hit"
   },
-  { "type": "pilotAligned", "data": "harvest" },
-  { "type": "hit", "data": { "from": "trigger", "name": "thruster_action" } },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 1008,
+    "type": "hit"
   },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 1009,
+    "type": "hit"
   },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 1010,
+    "type": "hit"
   },
-  { "type": "docked", "data": "harvest" },
-  { "type": "hit", "data": { "from": "port", "name": "valen-harvest_ikov" } },
-  { "type": "hit", "data": { "from": "port", "name": "mainpanel_cargo" } },
-  { "type": "upload", "data": "cargo" },
-  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
-  { "type": "hit", "data": { "from": "port", "name": "player" } },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "location_senni-harvest" }
+    "data": "portal",
+    "index": 1011,
+    "type": "docked"
   },
-  { "type": "pilotAligned", "data": "harvest" },
-  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
-  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
-  { "type": "hit", "data": { "from": "trigger", "name": "thruster_action" } },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": {
+      "from": "trigger",
+      "name": "location_loiqe-Loiqe"
+    },
+    "index": 1012,
+    "type": "hit"
   },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": "Loiqe",
+    "index": 1013,
+    "type": "pilotAligned"
   },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": {
+      "from": "trigger",
+      "name": "thruster_action"
+    },
+    "index": 1014,
+    "type": "hit"
   },
-  { "type": "docked", "data": "harvest" },
-  { "type": "hit", "data": { "from": "port", "name": "senni-harvest_eral" } },
-  { "type": "hit", "data": { "from": "port", "name": "mainpanel_cargo" } },
-  { "type": "upload", "data": "cargo" },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "location_senni-Horadric" }
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 1015,
+    "type": "hit"
   },
-  { "type": "pilotAligned", "data": "Horadric" },
-  { "type": "hit", "data": { "from": "trigger", "name": "thruster_action" } },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 1016,
+    "type": "hit"
   },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 1017,
+    "type": "hit"
   },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": "Loiqe",
+    "index": 1018,
+    "type": "docked"
   },
-  { "type": "docked", "data": "Horadric" },
   {
-    "type": "hit",
     "data": {
+      "event": "end-key",
       "from": "port",
-      "numberlessName": "console_line_#",
-      "event": "currency-2"
-    }
+      "numberlessName": "console_line_#"
+    },
+    "index": 1019,
+    "type": "hit"
   },
   {
-    "type": "hit",
     "data": {
       "from": "port",
-      "numberlessName": "senni-Horadric_input_#",
-      "event": null
-    }
+      "name": "loiqe-Loiqe"
+    },
+    "index": 1020,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "button_loiqe-Loiqe_install"
+    },
+    "index": 1021,
+    "type": "hit"
   },
-  { "type": "upload", "data": "senni-Horadric_input_#" },
   {
-    "type": "hit",
+    "data": "Loiqe",
+    "index": 1022,
+    "type": "pilotAligned"
+  },
+  {
     "data": {
       "from": "port",
-      "numberlessName": "console_line_#",
-      "event": "currency-3"
-    }
+      "name": "widget_map"
+    },
+    "index": 1023,
+    "type": "hit"
   },
   {
-    "type": "hit",
     "data": {
       "from": "port",
-      "numberlessName": "senni-Horadric_input_#",
-      "event": null
-    }
+      "name": "player"
+    },
+    "index": 1024,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "location_loiqe-spawn"
+    },
+    "index": 1025,
+    "type": "hit"
+  },
+  {
+    "data": "spawn",
+    "index": 1026,
+    "type": "pilotAligned"
   },
-  { "type": "combination", "data": "ikeral" },
   {
-    "type": "hit",
-    "data": { "from": "port", "name": "senni-Horadric_output_1" }
+    "data": {
+      "from": "port",
+      "name": "widget_map"
+    },
+    "index": 1027,
+    "type": "hit"
   },
-  { "type": "hit", "data": { "from": "port", "name": "mainpanel_cargo" } },
-  { "type": "upload", "data": "cargo" },
-  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
-  { "type": "hit", "data": { "from": "port", "name": "player" } },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "location_valen-harvest" }
+    "data": {
+      "from": "port",
+      "name": "widget_map"
+    },
+    "index": 1028,
+    "type": "hit"
   },
-  { "type": "pilotAligned", "data": "harvest" },
-  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
-  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
-  { "type": "hit", "data": { "from": "trigger", "name": "thruster_action" } },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": {
+      "from": "trigger",
+      "name": "thruster_action"
+    },
+    "index": 1029,
+    "type": "hit"
   },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 1030,
+    "type": "hit"
   },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 1031,
+    "type": "hit"
   },
-  { "type": "docked", "data": "harvest" },
-  { "type": "hit", "data": { "from": "port", "name": "valen-harvest_ikov" } },
-  { "type": "hit", "data": { "from": "port", "name": "mainpanel_cargo" } },
-  { "type": "upload", "data": "cargo" },
-  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
-  { "type": "hit", "data": { "from": "port", "name": "player" } },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "location_loiqe-portal" }
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 1032,
+    "type": "hit"
   },
-  { "type": "pilotAligned", "data": "portal" },
-  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
-  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
-  { "type": "hit", "data": { "from": "trigger", "name": "thruster_action" } },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": "spawn",
+    "index": 1033,
+    "type": "docked"
   },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": {
+      "from": "port",
+      "name": "loiqe-spawn_a teapot"
+    },
+    "index": 1034,
+    "type": "hit"
   },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": {
+      "from": "port",
+      "name": "mainpanel_cargo"
+    },
+    "index": 1035,
+    "type": "hit"
   },
-  { "type": "docked", "data": "portal" },
-  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
-  { "type": "hit", "data": { "from": "port", "name": "player" } },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "location_loiqe-port" }
+    "data": "cargo",
+    "index": 1036,
+    "type": "upload"
   },
-  { "type": "pilotAligned", "data": "port" },
-  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
-  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
-  { "type": "hit", "data": { "from": "trigger", "name": "thruster_action" } },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": {
+      "from": "port",
+      "name": "widget_map"
+    },
+    "index": 1037,
+    "type": "hit"
   },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": {
+      "from": "port",
+      "name": "player"
+    },
+    "index": 1038,
+    "type": "hit"
   },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": {
+      "from": "trigger",
+      "name": "location_loiqe-satellite"
+    },
+    "index": 1039,
+    "type": "hit"
   },
-  { "type": "docked", "data": "port" },
-  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
-  { "type": "hit", "data": { "from": "port", "name": "player" } },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "location_loiqe-Harvest" }
+    "data": "satellite",
+    "index": 1040,
+    "type": "pilotAligned"
   },
-  { "type": "pilotAligned", "data": "Harvest" },
-  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
-  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": {
+      "from": "port",
+      "name": "widget_map"
+    },
+    "index": 1041,
+    "type": "hit"
   },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": {
+      "from": "port",
+      "name": "widget_map"
+    },
+    "index": 1042,
+    "type": "hit"
   },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": {
+      "from": "trigger",
+      "name": "thruster_action"
+    },
+    "index": 1043,
+    "type": "hit"
   },
-  { "type": "docked", "data": "Harvest" },
-  { "type": "hit", "data": { "from": "port", "name": "loiqe-Harvest_alta" } },
-  { "type": "hit", "data": { "from": "port", "name": "mainpanel_cargo" } },
-  { "type": "upload", "data": "cargo" },
-  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
-  { "type": "hit", "data": { "from": "port", "name": "player" } },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "location_loiqe-Horadric" }
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 1044,
+    "type": "hit"
   },
-  { "type": "pilotAligned", "data": "Horadric" },
-  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
-  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
-  { "type": "hit", "data": { "from": "trigger", "name": "thruster_action" } },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 1045,
+    "type": "hit"
   },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 1046,
+    "type": "hit"
   },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": "satellite",
+    "index": 1047,
+    "type": "docked"
   },
-  { "type": "docked", "data": "Horadric" },
   {
-    "type": "hit",
     "data": {
       "from": "port",
-      "numberlessName": "console_line_#",
-      "event": "currency-1"
-    }
+      "name": "widget_map"
+    },
+    "index": 1048,
+    "type": "hit"
   },
   {
-    "type": "hit",
     "data": {
       "from": "port",
-      "numberlessName": "loiqe-Horadric_input_#",
-      "event": null
-    }
+      "name": "player"
+    },
+    "index": 1049,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "location_valen-void"
+    },
+    "index": 1050,
+    "type": "hit"
+  },
+  {
+    "data": "void",
+    "index": 1051,
+    "type": "pilotAligned"
   },
-  { "type": "upload", "data": "loiqe-Horadric_input_#" },
   {
-    "type": "hit",
     "data": {
       "from": "port",
-      "numberlessName": "console_line_#",
-      "event": "currency-2"
-    }
+      "name": "widget_map"
+    },
+    "index": 1052,
+    "type": "hit"
   },
   {
-    "type": "hit",
     "data": {
       "from": "port",
-      "numberlessName": "loiqe-Horadric_input_#",
-      "event": null
-    }
+      "name": "widget_map"
+    },
+    "index": 1053,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "thruster_action"
+    },
+    "index": 1054,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 1055,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 1056,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 1057,
+    "type": "hit"
   },
-  { "type": "combination", "data": "altiov" },
   {
-    "type": "hit",
-    "data": { "from": "port", "name": "loiqe-Horadric_output_1" }
+    "data": "void",
+    "index": 1058,
+    "type": "docked"
   },
-  { "type": "hit", "data": { "from": "port", "name": "mainpanel_cargo" } },
-  { "type": "upload", "data": "cargo" },
   {
-    "type": "hit",
     "data": {
+      "event": "echoes-1",
       "from": "port",
-      "numberlessName": "console_line_#",
-      "event": "currency-4"
-    }
+      "numberlessName": "console_line_#"
+    },
+    "index": 1059,
+    "type": "hit"
   },
   {
-    "type": "hit",
     "data": {
       "from": "port",
-      "numberlessName": "loiqe-Horadric_input_#",
-      "event": null
-    }
+      "name": "valen-void_want"
+    },
+    "index": 1060,
+    "type": "hit"
+  },
+  {
+    "data": "valen-void_want",
+    "index": 1061,
+    "type": "upload"
   },
-  { "type": "upload", "data": "loiqe-Horadric_input_#" },
   {
-    "type": "hit",
     "data": {
       "from": "port",
-      "numberlessName": "console_line_#",
-      "event": "currency-5"
-    }
+      "name": "valen-void_give"
+    },
+    "index": 1062,
+    "type": "hit"
   },
   {
-    "type": "hit",
     "data": {
       "from": "port",
-      "numberlessName": "loiqe-Horadric_input_#",
-      "event": null
-    }
+      "name": "mainpanel_cargo"
+    },
+    "index": 1063,
+    "type": "hit"
+  },
+  {
+    "data": "cargo",
+    "index": 1064,
+    "type": "upload"
   },
-  { "type": "combination", "data": "echo" },
   {
-    "type": "hit",
-    "data": { "from": "port", "name": "loiqe-Horadric_output_1" }
+    "data": {
+      "from": "port",
+      "name": "widget_map"
+    },
+    "index": 1065,
+    "type": "hit"
   },
-  { "type": "hit", "data": { "from": "port", "name": "mainpanel_cargo" } },
-  { "type": "upload", "data": "cargo" },
-  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
-  { "type": "hit", "data": { "from": "port", "name": "player" } },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "location_usul-station" }
+    "data": {
+      "from": "port",
+      "name": "player"
+    },
+    "index": 1066,
+    "type": "hit"
   },
-  { "type": "pilotAligned", "data": "station" },
-  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
-  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
-  { "type": "hit", "data": { "from": "trigger", "name": "thruster_action" } },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": {
+      "from": "trigger",
+      "name": "location_valen-Valen"
+    },
+    "index": 1067,
+    "type": "hit"
   },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": "Valen",
+    "index": 1068,
+    "type": "pilotAligned"
   },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": {
+      "from": "port",
+      "name": "widget_map"
+    },
+    "index": 1069,
+    "type": "hit"
   },
-  { "type": "docked", "data": "station" },
-  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
-  { "type": "hit", "data": { "from": "port", "name": "mainpanel_cargo" } },
-  { "type": "upload", "data": "cargo" },
   {
-    "type": "hit",
     "data": {
       "from": "port",
-      "numberlessName": "console_line_#",
-      "event": "map-2"
-    }
+      "name": "widget_map"
+    },
+    "index": 1070,
+    "type": "hit"
   },
-  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
-  { "type": "upload", "data": "widget_map" },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "location_usul-silence" }
+    "data": {
+      "from": "trigger",
+      "name": "thruster_action"
+    },
+    "index": 1071,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 1072,
+    "type": "hit"
   },
-  { "type": "pilotAligned", "data": "silence" },
-  { "type": "hit", "data": { "from": "trigger", "name": "thruster_action" } },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 1073,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 1074,
+    "type": "hit"
   },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": "Valen",
+    "index": 1075,
+    "type": "docked"
   },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": {
+      "event": "end-key",
+      "from": "port",
+      "numberlessName": "console_line_#"
+    },
+    "index": 1076,
+    "type": "hit"
   },
-  { "type": "docked", "data": "silence" },
   {
-    "type": "hit",
     "data": {
       "from": "port",
-      "numberlessName": "console_line_#",
-      "event": "currency-6"
-    }
+      "name": "valen-Valen"
+    },
+    "index": 1077,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "button_valen-Valen_install"
+    },
+    "index": 1078,
+    "type": "hit"
+  },
+  {
+    "data": "Valen",
+    "index": 1079,
+    "type": "pilotAligned"
   },
-  { "type": "hit", "data": { "from": "port", "name": "usul-silence_want" } },
-  { "type": "upload", "data": "usul-silence_want" },
-  { "type": "hit", "data": { "from": "port", "name": "usul-silence_give" } },
-  { "type": "hit", "data": { "from": "port", "name": "mainpanel_cargo" } },
-  { "type": "upload", "data": "cargo" },
-  { "type": "hit", "data": { "from": "port", "name": "widget_radio" } },
-  { "type": "hit", "data": { "from": "port", "name": "mainpanel_cargo" } },
-  { "type": "upload", "data": "cargo" },
   {
-    "type": "hit",
     "data": {
       "from": "port",
-      "numberlessName": "battery_slot_cell#",
-      "event": "battery-3"
-    }
+      "name": "widget_map"
+    },
+    "index": 1080,
+    "type": "hit"
   },
-  { "type": "hit", "data": { "from": "port", "name": "battery_slot_oxygen" } },
   {
-    "type": "hit",
     "data": {
       "from": "port",
-      "numberlessName": "console_line_#",
-      "event": "shield-1"
-    }
+      "name": "player"
+    },
+    "index": 1081,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "location_senni-bog"
+    },
+    "index": 1082,
+    "type": "hit"
   },
-  { "type": "hit", "data": { "from": "port", "name": "widget_shield" } },
-  { "skip": true, "type": "mission", "data": 17 },
-  { "type": "upload", "data": "widget_shield" },
-  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
-  { "type": "hit", "data": { "from": "port", "name": "player" } },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "location_loiqe-portal" }
+    "data": "bog",
+    "index": 1083,
+    "type": "pilotAligned"
   },
-  { "type": "pilotAligned", "data": "portal" },
-  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
-  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
-  { "type": "hit", "data": { "from": "trigger", "name": "thruster_action" } },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": {
+      "from": "port",
+      "name": "widget_map"
+    },
+    "index": 1084,
+    "type": "hit"
   },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": {
+      "from": "port",
+      "name": "widget_map"
+    },
+    "index": 1085,
+    "type": "hit"
   },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": {
+      "from": "trigger",
+      "name": "thruster_action"
+    },
+    "index": 1086,
+    "type": "hit"
   },
-  { "type": "docked", "data": "portal" },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "location_loiqe-Loiqe" }
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 1087,
+    "type": "hit"
   },
-  { "type": "pilotAligned", "data": "Loiqe" },
-  { "type": "hit", "data": { "from": "trigger", "name": "thruster_action" } },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 1088,
+    "type": "hit"
   },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 1089,
+    "type": "hit"
   },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": "bog",
+    "index": 1090,
+    "type": "docked"
   },
-  { "type": "docked", "data": "Loiqe" },
   {
-    "type": "hit",
     "data": {
+      "event": "kelp",
       "from": "port",
-      "numberlessName": "console_line_#",
-      "event": "end-key"
-    }
+      "numberlessName": "console_line_#"
+    },
+    "index": 1091,
+    "type": "hit"
   },
-  { "type": "hit", "data": { "from": "port", "name": "loiqe-Loiqe" } },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "button_loiqe-Loiqe_install" }
+    "data": {
+      "from": "port",
+      "name": "senni-bog_want"
+    },
+    "index": 1092,
+    "type": "hit"
   },
-  { "type": "pilotAligned", "data": "Loiqe" },
-  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
-  { "type": "hit", "data": { "from": "port", "name": "player" } },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "location_loiqe-spawn" }
+    "data": "senni-bog_want",
+    "index": 1093,
+    "type": "upload"
   },
-  { "type": "pilotAligned", "data": "spawn" },
-  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
-  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
-  { "type": "hit", "data": { "from": "trigger", "name": "thruster_action" } },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": {
+      "from": "port",
+      "name": "senni-bog_give"
+    },
+    "index": 1094,
+    "type": "hit"
   },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": {
+      "from": "port",
+      "name": "mainpanel_cargo"
+    },
+    "index": 1095,
+    "type": "hit"
   },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": "cargo",
+    "index": 1096,
+    "type": "upload"
   },
-  { "type": "docked", "data": "spawn" },
-  { "type": "hit", "data": { "from": "port", "name": "loiqe-spawn_a teapot" } },
-  { "type": "hit", "data": { "from": "port", "name": "mainpanel_cargo" } },
-  { "type": "upload", "data": "cargo" },
-  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
-  { "type": "hit", "data": { "from": "port", "name": "player" } },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "location_loiqe-satellite" }
+    "data": {
+      "from": "trigger",
+      "name": "location_senni-Senni"
+    },
+    "index": 1097,
+    "type": "hit"
   },
-  { "type": "pilotAligned", "data": "satellite" },
-  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
-  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
-  { "type": "hit", "data": { "from": "trigger", "name": "thruster_action" } },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": "Senni",
+    "index": 1098,
+    "type": "pilotAligned"
   },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": {
+      "from": "trigger",
+      "name": "thruster_action"
+    },
+    "index": 1099,
+    "type": "hit"
   },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 1100,
+    "type": "hit"
   },
-  { "type": "docked", "data": "satellite" },
-  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
-  { "type": "hit", "data": { "from": "port", "name": "player" } },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "location_valen-void" }
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 1101,
+    "type": "hit"
   },
-  { "type": "pilotAligned", "data": "void" },
-  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
-  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
-  { "type": "hit", "data": { "from": "trigger", "name": "thruster_action" } },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 1102,
+    "type": "hit"
   },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": "Senni",
+    "index": 1103,
+    "type": "docked"
   },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": {
+      "event": "end-key",
+      "from": "port",
+      "numberlessName": "console_line_#"
+    },
+    "index": 1104,
+    "type": "hit"
   },
-  { "type": "docked", "data": "void" },
   {
-    "type": "hit",
     "data": {
       "from": "port",
-      "numberlessName": "console_line_#",
-      "event": "echoes-1"
-    }
+      "name": "senni-Senni"
+    },
+    "index": 1105,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "button_senni-Senni_install"
+    },
+    "index": 1106,
+    "type": "hit"
+  },
+  {
+    "data": "Senni",
+    "index": 1107,
+    "type": "pilotAligned"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "location_senni-cargo"
+    },
+    "index": 1108,
+    "type": "hit"
+  },
+  {
+    "data": "cargo",
+    "index": 1109,
+    "type": "pilotAligned"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "thruster_action"
+    },
+    "index": 1110,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 1111,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 1112,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 1113,
+    "type": "hit"
   },
-  { "type": "hit", "data": { "from": "port", "name": "valen-void_want" } },
-  { "type": "upload", "data": "valen-void_want" },
-  { "type": "hit", "data": { "from": "port", "name": "valen-void_give" } },
-  { "type": "hit", "data": { "from": "port", "name": "mainpanel_cargo" } },
-  { "type": "upload", "data": "cargo" },
-  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
-  { "type": "hit", "data": { "from": "port", "name": "player" } },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "location_valen-Valen" }
+    "data": "cargo",
+    "index": 1114,
+    "type": "docked"
   },
-  { "type": "pilotAligned", "data": "Valen" },
-  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
-  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
-  { "type": "hit", "data": { "from": "trigger", "name": "thruster_action" } },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": {
+      "event": "battery-3",
+      "from": "port",
+      "numberlessName": "battery_slot_cell#"
+    },
+    "index": 1115,
+    "type": "hit"
   },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": {
+      "from": "port",
+      "name": "battery_slot_radio"
+    },
+    "index": 1116,
+    "type": "hit"
   },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": {
+      "event": "record5",
+      "from": "port",
+      "numberlessName": "console_line_#"
+    },
+    "index": 1117,
+    "type": "hit"
   },
-  { "type": "docked", "data": "Valen" },
   {
-    "type": "hit",
     "data": {
       "from": "port",
-      "numberlessName": "console_line_#",
-      "event": "end-key"
-    }
+      "name": "widget_radio"
+    },
+    "index": 1118,
+    "type": "hit"
+  },
+  {
+    "data": "widget_radio",
+    "index": 1119,
+    "type": "upload"
   },
-  { "type": "hit", "data": { "from": "port", "name": "valen-Valen" } },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "button_valen-Valen_install" }
+    "data": {
+      "from": "port",
+      "name": "widget_map"
+    },
+    "index": 1120,
+    "type": "hit"
   },
-  { "type": "pilotAligned", "data": "Valen" },
-  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
-  { "type": "hit", "data": { "from": "port", "name": "player" } },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "location_senni-bog" }
+    "data": {
+      "from": "port",
+      "name": "player"
+    },
+    "index": 1121,
+    "type": "hit"
   },
-  { "type": "pilotAligned", "data": "bog" },
-  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
-  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
-  { "type": "hit", "data": { "from": "trigger", "name": "thruster_action" } },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": {
+      "from": "trigger",
+      "name": "location_usul-annex"
+    },
+    "index": 1122,
+    "type": "hit"
   },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": "annex",
+    "index": 1123,
+    "type": "pilotAligned"
   },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": {
+      "from": "port",
+      "name": "widget_map"
+    },
+    "index": 1124,
+    "type": "hit"
   },
-  { "type": "docked", "data": "bog" },
   {
-    "type": "hit",
     "data": {
       "from": "port",
-      "numberlessName": "console_line_#",
-      "event": "kelp"
-    }
+      "name": "widget_map"
+    },
+    "index": 1125,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "thruster_action"
+    },
+    "index": 1126,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 1127,
+    "type": "hit"
   },
-  { "type": "hit", "data": { "from": "port", "name": "senni-bog_want" } },
-  { "type": "upload", "data": "senni-bog_want" },
-  { "type": "hit", "data": { "from": "port", "name": "senni-bog_give" } },
-  { "type": "hit", "data": { "from": "port", "name": "mainpanel_cargo" } },
-  { "type": "upload", "data": "cargo" },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "location_senni-Senni" }
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 1128,
+    "type": "hit"
   },
-  { "type": "pilotAligned", "data": "Senni" },
-  { "type": "hit", "data": { "from": "trigger", "name": "thruster_action" } },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 1129,
+    "type": "hit"
   },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": "annex",
+    "index": 1130,
+    "type": "docked"
   },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": {
+      "event": "battery-3",
+      "from": "port",
+      "numberlessName": "battery_slot_cell#"
+    },
+    "index": 1131,
+    "type": "hit"
   },
-  { "type": "docked", "data": "Senni" },
   {
-    "type": "hit",
     "data": {
       "from": "port",
-      "numberlessName": "console_line_#",
-      "event": "end-key"
-    }
+      "name": "battery_slot_oxygen"
+    },
+    "index": 1132,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "location_usul-Usul"
+    },
+    "index": 1133,
+    "type": "hit"
+  },
+  {
+    "data": "Usul",
+    "index": 1134,
+    "type": "pilotAligned"
   },
-  { "type": "hit", "data": { "from": "port", "name": "senni-Senni" } },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "button_senni-Senni_install" }
+    "data": {
+      "from": "trigger",
+      "name": "thruster_action"
+    },
+    "index": 1135,
+    "type": "hit"
   },
-  { "type": "pilotAligned", "data": "Senni" },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "location_senni-cargo" }
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 1136,
+    "type": "hit"
   },
-  { "type": "pilotAligned", "data": "cargo" },
-  { "type": "hit", "data": { "from": "trigger", "name": "thruster_action" } },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 1137,
+    "type": "hit"
   },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 1138,
+    "type": "hit"
   },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": "Usul",
+    "index": 1139,
+    "type": "docked"
   },
-  { "type": "docked", "data": "cargo" },
   {
-    "type": "hit",
     "data": {
+      "event": "end-key",
       "from": "port",
-      "numberlessName": "battery_slot_cell#",
-      "event": "battery-3"
-    }
+      "numberlessName": "console_line_#"
+    },
+    "index": 1140,
+    "type": "hit"
   },
-  { "type": "hit", "data": { "from": "port", "name": "battery_slot_radio" } },
   {
-    "type": "hit",
     "data": {
       "from": "port",
-      "numberlessName": "console_line_#",
-      "event": "record5"
-    }
+      "name": "usul-Usul"
+    },
+    "index": 1141,
+    "type": "hit"
   },
-  { "type": "hit", "data": { "from": "port", "name": "widget_radio" } },
-  { "type": "upload", "data": "widget_radio" },
-  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
-  { "type": "hit", "data": { "from": "port", "name": "player" } },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "location_usul-annex" }
+    "data": {
+      "from": "trigger",
+      "name": "button_usul-Usul_install"
+    },
+    "index": 1142,
+    "type": "hit"
   },
-  { "type": "pilotAligned", "data": "annex" },
-  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
-  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
-  { "type": "hit", "data": { "from": "trigger", "name": "thruster_action" } },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": 18,
+    "index": 1143,
+    "skip": true,
+    "type": "mission"
   },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": "Usul",
+    "index": 1144,
+    "type": "pilotAligned"
   },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": {
+      "from": "port",
+      "name": "widget_map"
+    },
+    "index": 1145,
+    "type": "hit"
   },
-  { "type": "docked", "data": "annex" },
   {
-    "type": "hit",
     "data": {
       "from": "port",
-      "numberlessName": "battery_slot_cell#",
-      "event": "battery-3"
-    }
+      "name": "mainpanel_cargo"
+    },
+    "index": 1146,
+    "type": "hit"
+  },
+  {
+    "data": "cargo",
+    "index": 1147,
+    "type": "upload"
   },
-  { "type": "hit", "data": { "from": "port", "name": "battery_slot_oxygen" } },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "location_usul-Usul" }
+    "data": {
+      "event": "map-1",
+      "from": "port",
+      "numberlessName": "console_line_#"
+    },
+    "index": 1148,
+    "type": "hit"
   },
-  { "type": "pilotAligned", "data": "Usul" },
-  { "type": "hit", "data": { "from": "trigger", "name": "thruster_action" } },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": {
+      "from": "port",
+      "name": "widget_map"
+    },
+    "index": 1149,
+    "type": "hit"
   },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": "widget_map",
+    "index": 1150,
+    "type": "upload"
   },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": {
+      "from": "port",
+      "name": "widget_map"
+    },
+    "index": 1151,
+    "type": "hit"
   },
-  { "type": "docked", "data": "Usul" },
   {
-    "type": "hit",
     "data": {
       "from": "port",
-      "numberlessName": "console_line_#",
-      "event": "end-key"
-    }
+      "name": "player"
+    },
+    "index": 1152,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "location_usul-transit"
+    },
+    "index": 1153,
+    "type": "hit"
   },
-  { "type": "hit", "data": { "from": "port", "name": "usul-Usul" } },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "button_usul-Usul_install" }
+    "data": {
+      "from": "port",
+      "name": "widget_map"
+    },
+    "index": 1154,
+    "type": "hit"
   },
-  { "skip": true, "type": "mission", "data": 18 },
-  { "type": "pilotAligned", "data": "Usul" },
-  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
-  { "type": "hit", "data": { "from": "port", "name": "mainpanel_cargo" } },
-  { "type": "upload", "data": "cargo" },
   {
-    "type": "hit",
     "data": {
       "from": "port",
-      "numberlessName": "console_line_#",
-      "event": "map-1"
-    }
+      "name": "widget_map"
+    },
+    "index": 1155,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "thruster_action"
+    },
+    "index": 1156,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 1157,
+    "type": "hit"
+  },
+  {
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 1158,
+    "type": "hit"
   },
-  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
-  { "type": "upload", "data": "widget_map" },
-  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
-  { "type": "hit", "data": { "from": "port", "name": "player" } },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "location_usul-transit" }
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 1159,
+    "type": "hit"
+  },
+  {
+    "data": "transit",
+    "index": 1160,
+    "type": "docked"
+  },
+  {
+    "data": {
+      "from": "port",
+      "name": "widget_map"
+    },
+    "index": 1161,
+    "type": "hit"
   },
-  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
-  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
-  { "type": "hit", "data": { "from": "trigger", "name": "thruster_action" } },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": {
+      "from": "port",
+      "name": "mainpanel_cargo"
+    },
+    "index": 1162,
+    "type": "hit"
   },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": "cargo",
+    "index": 1163,
+    "type": "upload"
   },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": {
+      "event": "map-2",
+      "from": "port",
+      "numberlessName": "console_line_#"
+    },
+    "index": 1164,
+    "type": "hit"
   },
-  { "type": "docked", "data": "transit" },
-  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
-  { "type": "hit", "data": { "from": "port", "name": "mainpanel_cargo" } },
-  { "type": "upload", "data": "cargo" },
   {
-    "type": "hit",
     "data": {
       "from": "port",
-      "numberlessName": "console_line_#",
-      "event": "map-2"
-    }
+      "name": "widget_map"
+    },
+    "index": 1165,
+    "type": "hit"
+  },
+  {
+    "data": "widget_map",
+    "index": 1166,
+    "type": "upload"
   },
-  { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
-  { "type": "upload", "data": "widget_map" },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "location_close-close" }
+    "data": {
+      "from": "trigger",
+      "name": "location_close-close"
+    },
+    "index": 1167,
+    "type": "hit"
   },
-  { "type": "hit", "data": { "from": "trigger", "name": "thruster_action" } },
   {
-    "type": "hit",
-    "data": { "from": "trigger", "name": "thruster_accelerate" }
+    "data": {
+      "from": "trigger",
+      "name": "thruster_action"
+    },
+    "index": 1168,
+    "type": "hit"
   },
-  { "skip": true, "type": "mission", "data": 19 }
+  {
+    "data": {
+      "from": "trigger",
+      "name": "thruster_accelerate"
+    },
+    "index": 1169,
+    "type": "hit"
+  },
+  {
+    "data": 19,
+    "index": 1170,
+    "skip": true,
+    "type": "mission"
+  }
 ]

--- a/verreciel_js/media/walkthrough.json
+++ b/verreciel_js/media/walkthrough.json
@@ -1,6 +1,6 @@
 [
-  { "type": "mission", "data": 0 },
-  { "type": "playerUnlock", "data": 0 },
+  { "skip": true, "type": "mission", "data": 0 },
+  { "skip": true, "type": "playerUnlock", "data": 0 },
   {
     "type": "hit",
     "data": {
@@ -30,21 +30,21 @@
     "type": "hit",
     "data": { "from": "trigger", "name": "thruster_accelerate" }
   },
-  { "type": "mission", "data": 0 },
+  { "skip": true, "type": "mission", "data": 0 },
   { "type": "docked", "data": "City" },
   {
     "type": "hit",
     "data": {
       "from": "port",
       "numberlessName": "console_line_#",
-      "event": null
+      "event": "currency-1"
     }
   },
   { "type": "hit", "data": { "from": "port", "name": "loiqe-City_want" } },
   { "type": "upload", "data": "loiqe-City_want" },
   { "type": "hit", "data": { "from": "port", "name": "loiqe-City_give" } },
   { "type": "hit", "data": { "from": "port", "name": "mainpanel_cargo" } },
-  { "type": "mission", "data": 1 },
+  { "skip": true, "type": "mission", "data": 1 },
   { "type": "install", "data": "map" },
   {
     "type": "hit",
@@ -53,7 +53,7 @@
   { "type": "playerUnlock", "data": -135 },
   { "type": "hit", "data": { "from": "port", "name": "mainpanel_radar" } },
   { "type": "hit", "data": { "from": "port", "name": "mainpanel_pilot" } },
-  { "type": "mission", "data": 2 },
+  { "skip": true, "type": "mission", "data": 2 },
   { "type": "pilotAligned", "data": "satellite" },
   { "type": "hit", "data": { "from": "trigger", "name": "thruster_action" } },
   {
@@ -94,7 +94,7 @@
       "event": null
     }
   },
-  { "type": "upload", "data": "loiqe-Horadric_input_2" },
+  { "type": "upload", "data": "loiqe-Horadric_input_#" },
   {
     "type": "hit",
     "data": {
@@ -117,7 +117,7 @@
     "data": { "from": "port", "name": "loiqe-Horadric_output_1" }
   },
   { "type": "hit", "data": { "from": "port", "name": "mainpanel_cargo" } },
-  { "type": "mission", "data": 3 },
+  { "skip": true, "type": "mission", "data": 3 },
   { "type": "install", "data": "exploration" },
   {
     "type": "hit",
@@ -213,7 +213,7 @@
       "event": null
     }
   },
-  { "type": "upload", "data": "battery_slot_cell2" },
+  { "type": "upload", "data": "battery_slot_cell#" },
   {
     "type": "hit",
     "data": { "from": "trigger", "name": "location_valen-harvest" }
@@ -252,7 +252,7 @@
     "data": {
       "from": "port",
       "numberlessName": "console_line_#",
-      "event": null
+      "event": "currency-2"
     }
   },
   { "type": "hit", "data": { "from": "port", "name": "valen-station" } },
@@ -280,7 +280,7 @@
     }
   },
   { "type": "hit", "data": { "from": "port", "name": "widget_radio" } },
-  { "type": "mission", "data": 6 },
+  { "skip": true, "type": "mission", "data": 6 },
   { "type": "upload", "data": "widget_radio" },
   {
     "type": "hit",
@@ -302,7 +302,7 @@
     "data": {
       "from": "port",
       "numberlessName": "valen-Bank_slot_#",
-      "event": null
+      "event": "waste"
     }
   },
   { "type": "hit", "data": { "from": "port", "name": "mainpanel_cargo" } },
@@ -312,7 +312,7 @@
     "data": {
       "from": "port",
       "numberlessName": "console_line_#",
-      "event": null
+      "event": "waste"
     }
   },
   { "type": "hit", "data": { "from": "port", "name": "mainpanel_hatch" } },
@@ -327,7 +327,7 @@
     }
   },
   { "type": "hit", "data": { "from": "port", "name": "mainpanel_cargo" } },
-  { "type": "mission", "data": 8 },
+  { "skip": true, "type": "mission", "data": 8 },
   { "type": "upload", "data": "cargo" },
   {
     "type": "hit",
@@ -497,7 +497,7 @@
     "data": {
       "from": "port",
       "numberlessName": "console_line_#",
-      "event": null
+      "event": "currency-1"
     }
   },
   {
@@ -508,13 +508,13 @@
       "event": null
     }
   },
-  { "type": "upload", "data": "loiqe-Horadric_input_2" },
+  { "type": "upload", "data": "loiqe-Horadric_input_#" },
   {
     "type": "hit",
     "data": {
       "from": "port",
       "numberlessName": "console_line_#",
-      "event": null
+      "event": "currency-2"
     }
   },
   {
@@ -582,7 +582,7 @@
     "data": {
       "from": "port",
       "numberlessName": "console_line_#",
-      "event": null
+      "event": "currency-4"
     }
   },
   { "type": "hit", "data": { "from": "port", "name": "loiqe-port_want" } },
@@ -684,7 +684,7 @@
     "data": {
       "from": "port",
       "numberlessName": "console_line_#",
-      "event": null
+      "event": "currency-3"
     }
   },
   { "type": "hit", "data": { "from": "port", "name": "senni-station" } },
@@ -746,8 +746,8 @@
       "event": null
     }
   },
-  { "type": "mission", "data": 12 },
-  { "type": "upload", "data": "battery_slot_cell3" },
+  { "skip": true, "type": "mission", "data": 12 },
+  { "type": "upload", "data": "battery_slot_cell#" },
   { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
   { "type": "hit", "data": { "from": "port", "name": "player" } },
   { "type": "mission", "data": 13 },
@@ -1037,7 +1037,7 @@
       "event": null
     }
   },
-  { "type": "upload", "data": "valen-Bank_slot_1" },
+  { "type": "upload", "data": "valen-Bank_slot_#" },
   {
     "type": "hit",
     "data": {
@@ -1054,7 +1054,7 @@
       "event": null
     }
   },
-  { "type": "upload", "data": "valen-Bank_slot_2" },
+  { "type": "upload", "data": "valen-Bank_slot_#" },
   {
     "type": "hit",
     "data": {
@@ -1071,7 +1071,7 @@
       "event": null
     }
   },
-  { "type": "upload", "data": "valen-Bank_slot_3" },
+  { "type": "upload", "data": "valen-Bank_slot_#" },
   {
     "type": "hit",
     "data": { "from": "trigger", "name": "location_valen-harvest" }
@@ -1125,7 +1125,7 @@
     "data": {
       "from": "port",
       "numberlessName": "console_line_#",
-      "event": null
+      "event": "currency-2"
     }
   },
   {
@@ -1136,13 +1136,13 @@
       "event": null
     }
   },
-  { "type": "upload", "data": "senni-Horadric_input_2" },
+  { "type": "upload", "data": "senni-Horadric_input_#" },
   {
     "type": "hit",
     "data": {
       "from": "port",
       "numberlessName": "console_line_#",
-      "event": null
+      "event": "currency-3"
     }
   },
   {
@@ -1176,7 +1176,7 @@
       "event": null
     }
   },
-  { "type": "upload", "data": "senni-Horadric_input_2" },
+  { "type": "upload", "data": "senni-Horadric_input_#" },
   {
     "type": "hit",
     "data": {
@@ -1297,7 +1297,7 @@
     "data": {
       "from": "port",
       "numberlessName": "console_line_#",
-      "event": null
+      "event": "currency-5"
     }
   },
   { "type": "hit", "data": { "from": "port", "name": "loiqe-fog_want" } },
@@ -1367,7 +1367,7 @@
       "event": null
     }
   },
-  { "type": "upload", "data": "loiqe-Horadric_input_2" },
+  { "type": "upload", "data": "loiqe-Horadric_input_#" },
   {
     "type": "hit",
     "data": {
@@ -1519,7 +1519,7 @@
       "event": null
     }
   },
-  { "type": "upload", "data": "valen-Bank_slot_4" },
+  { "type": "upload", "data": "valen-Bank_slot_#" },
   {
     "type": "hit",
     "data": { "from": "trigger", "name": "location_valen-harvest" }
@@ -1592,7 +1592,7 @@
     "data": {
       "from": "port",
       "numberlessName": "console_line_#",
-      "event": null
+      "event": "currency-2"
     }
   },
   {
@@ -1603,13 +1603,13 @@
       "event": null
     }
   },
-  { "type": "upload", "data": "senni-Horadric_input_2" },
+  { "type": "upload", "data": "senni-Horadric_input_#" },
   {
     "type": "hit",
     "data": {
       "from": "port",
       "numberlessName": "console_line_#",
-      "event": null
+      "event": "currency-3"
     }
   },
   {
@@ -1678,7 +1678,7 @@
     "data": {
       "from": "port",
       "numberlessName": "console_line_#",
-      "event": null
+      "event": "currency-5"
     }
   },
   { "type": "hit", "data": { "from": "port", "name": "usul-station" } },
@@ -1687,7 +1687,7 @@
     "type": "hit",
     "data": { "from": "trigger", "name": "button_usul-station_install" }
   },
-  { "type": "mission", "data": 15 },
+  { "skip": true, "type": "mission", "data": 15 },
   { "type": "playerUnlock", "data": 0 },
   {
     "type": "hit",
@@ -1799,7 +1799,7 @@
       "event": null
     }
   },
-  { "type": "upload", "data": "senni-Horadric_input_2" },
+  { "type": "upload", "data": "senni-Horadric_input_#" },
   {
     "type": "hit",
     "data": {
@@ -1839,7 +1839,7 @@
       "event": null
     }
   },
-  { "type": "upload", "data": "senni-Horadric_input_2" },
+  { "type": "upload", "data": "senni-Horadric_input_#" },
   {
     "type": "hit",
     "data": {
@@ -1879,7 +1879,7 @@
       "event": null
     }
   },
-  { "type": "upload", "data": "senni-Horadric_input_2" },
+  { "type": "upload", "data": "senni-Horadric_input_#" },
   {
     "type": "hit",
     "data": {
@@ -2176,7 +2176,7 @@
     "data": {
       "from": "port",
       "numberlessName": "console_line_#",
-      "event": null
+      "event": "currency-2"
     }
   },
   {
@@ -2187,13 +2187,13 @@
       "event": null
     }
   },
-  { "type": "upload", "data": "senni-Horadric_input_2" },
+  { "type": "upload", "data": "senni-Horadric_input_#" },
   {
     "type": "hit",
     "data": {
       "from": "port",
       "numberlessName": "console_line_#",
-      "event": null
+      "event": "currency-3"
     }
   },
   {
@@ -2336,7 +2336,7 @@
     "data": {
       "from": "port",
       "numberlessName": "console_line_#",
-      "event": null
+      "event": "currency-1"
     }
   },
   {
@@ -2347,13 +2347,13 @@
       "event": null
     }
   },
-  { "type": "upload", "data": "loiqe-Horadric_input_2" },
+  { "type": "upload", "data": "loiqe-Horadric_input_#" },
   {
     "type": "hit",
     "data": {
       "from": "port",
       "numberlessName": "console_line_#",
-      "event": null
+      "event": "currency-2"
     }
   },
   {
@@ -2376,7 +2376,7 @@
     "data": {
       "from": "port",
       "numberlessName": "console_line_#",
-      "event": null
+      "event": "currency-4"
     }
   },
   {
@@ -2387,13 +2387,13 @@
       "event": null
     }
   },
-  { "type": "upload", "data": "loiqe-Horadric_input_2" },
+  { "type": "upload", "data": "loiqe-Horadric_input_#" },
   {
     "type": "hit",
     "data": {
       "from": "port",
       "numberlessName": "console_line_#",
-      "event": null
+      "event": "currency-5"
     }
   },
   {
@@ -2471,7 +2471,7 @@
     "data": {
       "from": "port",
       "numberlessName": "console_line_#",
-      "event": null
+      "event": "currency-6"
     }
   },
   { "type": "hit", "data": { "from": "port", "name": "usul-silence_want" } },
@@ -2500,7 +2500,7 @@
     }
   },
   { "type": "hit", "data": { "from": "port", "name": "widget_shield" } },
-  { "type": "mission", "data": 17 },
+  { "skip": true, "type": "mission", "data": 17 },
   { "type": "upload", "data": "widget_shield" },
   { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
   { "type": "hit", "data": { "from": "port", "name": "player" } },
@@ -2851,7 +2851,7 @@
     "type": "hit",
     "data": { "from": "trigger", "name": "button_usul-Usul_install" }
   },
-  { "type": "mission", "data": 18 },
+  { "skip": true, "type": "mission", "data": 18 },
   { "type": "pilotAligned", "data": "Usul" },
   { "type": "hit", "data": { "from": "port", "name": "widget_map" } },
   { "type": "hit", "data": { "from": "port", "name": "mainpanel_cargo" } },
@@ -2910,5 +2910,5 @@
     "type": "hit",
     "data": { "from": "trigger", "name": "thruster_accelerate" }
   },
-  { "type": "mission", "data": 19 }
+  { "skip": true, "type": "mission", "data": 19 }
 ]

--- a/verreciel_js/package.json
+++ b/verreciel_js/package.json
@@ -8,7 +8,7 @@
   "license": "CC-BY-4.0",
   "scripts": {
     "start": "electron .",
-    "fmt": "prettier --write main.js 'scripts/**/*.js' 'links/**/*.css'",
+    "fmt": "prettier --write main.js 'scripts/**/*.js' 'links/**/*.css' 'media/**/*.json'",
     "stretch": "prettier --print-width 1000 --write main.js 'scripts/**/*.js' 'links/**/*.css'"
   },
   "dependencies": {

--- a/verreciel_js/scripts/animations/animation.js
+++ b/verreciel_js/scripts/animations/animation.js
@@ -22,7 +22,7 @@ class Animation {
 
     this.tick();
     this.started = true;
-    this.lastFrameTime += this.delay * 1000;
+    this.lastFrameTime += this.delay * 1000 / verreciel.game.gameSpeed;
     delay(this.delay, this.tick.bind(this));
   }
 
@@ -34,7 +34,8 @@ class Animation {
     let secondsElapsed = (frameTime - this.lastFrameTime) / 1000;
     this.lastFrameTime = frameTime;
 
-    var percentElapsed = secondsElapsed / this.duration;
+    var percentElapsed =
+      secondsElapsed / this.duration * verreciel.game.gameSpeed;
     this.percent += percentElapsed;
 
     if (this.percent > 1) {

--- a/verreciel_js/scripts/collections/locations.js
+++ b/verreciel_js/scripts/collections/locations.js
@@ -42,14 +42,7 @@ class Loiqe {
       "Harvest",
       this.system,
       new THREE.Vector2(this.offset.x, this.offset.y - 2),
-      new Item(
-        verreciel.items.currency1.name,
-        ItemTypes.currency,
-        null,
-        "",
-        false,
-        null
-      )
+      Item.like(verreciel.items.currency1)
     );
   }
 
@@ -264,14 +257,7 @@ class Valen {
       "harvest",
       this.system,
       new THREE.Vector2(this.offset.x, this.offset.y + 2),
-      new Item(
-        verreciel.items.currency2.name,
-        ItemTypes.currency,
-        null,
-        "",
-        false,
-        null
-      )
+      Item.like(verreciel.items.currency2)
     );
   }
 
@@ -409,14 +395,7 @@ class Senni {
       "harvest",
       this.system,
       new THREE.Vector2(this.offset.x, this.offset.y + 1),
-      new Item(
-        verreciel.items.currency3.name,
-        ItemTypes.currency,
-        null,
-        "",
-        false,
-        null
-      )
+      Item.like(verreciel.items.currency3)
     );
   }
 

--- a/verreciel_js/scripts/collections/missions.js
+++ b/verreciel_js/scripts/collections/missions.js
@@ -146,7 +146,7 @@ class Missions {
     };
     m.quests = [
       new Quest(
-        "Route " + i.currency1.name + " to verreciel.cargo",
+        "Route " + i.currency1.name + " to cargo",
         u.loiqe_harvest,
         function() {
           return (
@@ -165,7 +165,7 @@ class Missions {
         function() {}
       ),
       new Quest(
-        "Route " + i.valenPortalFragment1.name + " to verreciel.cargo",
+        "Route " + i.valenPortalFragment1.name + " to cargo",
         null,
         function() {
           return verreciel.cargo.contains(i.valenPortalFragment1) == true;

--- a/verreciel_js/scripts/collections/missions.js
+++ b/verreciel_js/scripts/collections/missions.js
@@ -1649,9 +1649,9 @@ class Missions {
     for (let mission of this.story) {
       if (mission.isCompleted == false) {
         this.currentMission = mission;
-        console.log("# ---------------------------");
-        console.log("# MISSION  | Reached: " + this.currentMission.id);
-        console.log("# ---------------------------");
+        console.info("# ---------------------------");
+        console.info("# MISSION  | Reached: " + this.currentMission.id);
+        console.info("# ---------------------------");
         verreciel.game.save(this.currentMission.id);
         return;
       }

--- a/verreciel_js/scripts/collections/missions.js
+++ b/verreciel_js/scripts/collections/missions.js
@@ -568,7 +568,7 @@ class Missions {
         function() {}
       ),
       new Quest(
-        "Jetison Waste",
+        "Jettison Waste",
         null,
         function() {
           return verreciel.hatch.count > 0;

--- a/verreciel_js/scripts/components/scenebutton.js
+++ b/verreciel_js/scripts/components/scenebutton.js
@@ -2,13 +2,13 @@
 //  Copyright © 2017 XXIIVV. All rights reserved.
 
 class SceneButton extends Empty {
-  constructor(host, text, operation, width = 0.65) {
+  constructor(host, name, text, operation, width = 0.65) {
     super();
     this.text = text;
     this.host = host;
     this.operation = operation;
 
-    this.trigger = new SceneTrigger(this, 2, 0.5, 2);
+    this.trigger = new SceneTrigger(this, "button_" + name, 2, 0.5, 2);
     this.trigger.add(
       new SceneLine(
         [

--- a/verreciel_js/scripts/components/scenehandle.js
+++ b/verreciel_js/scripts/components/scenehandle.js
@@ -2,7 +2,7 @@
 //  Copyright © 2017 XXIIVV. All rights reserved.
 
 class SceneHandle extends Empty {
-  constructor(destination, host) {
+  constructor(destination, host, name) {
     // assertArgs(arguments, 2);
     super();
     this.isEnabled = true;
@@ -39,7 +39,13 @@ class SceneHandle extends Empty {
     );
     this.add(this.selectionLine);
 
-    this.trigger = new SceneTrigger(this, 2, 0.5, 0);
+    this.trigger = new SceneTrigger(
+      this,
+      "handle_" + this.host.name,
+      2,
+      0.5,
+      0
+    );
     this.trigger.updateChildrenColors(verreciel.red); // Implies this was never used?
     this.add(this.trigger);
   }

--- a/verreciel_js/scripts/components/sceneline.js
+++ b/verreciel_js/scripts/components/sceneline.js
@@ -46,7 +46,7 @@ class SceneLine extends SceneDrawNode {
       this.geometry.dispose();
       this.geometry = new THREE.Geometry();
       this.element.geometry = this.geometry;
-      // console.log("EXPAND:", oldLength, "-->", this.vertices.length);
+      // console.debug("EXPAND:", oldLength, "-->", this.vertices.length);
     }
 
     this.geometry.vertices = vertices;

--- a/verreciel_js/scripts/components/scenenode.js
+++ b/verreciel_js/scripts/components/scenenode.js
@@ -5,7 +5,7 @@ class SceneNode {
   constructor() {
     // assertArgs(arguments, 0);
     this.id = SceneNode.ids++;
-    // console.log(this.id);
+    // console.debug(this.id);
     this.children = [];
 
     if (DEBUG_REPORT_NODE_USE) {
@@ -93,15 +93,15 @@ class SceneNode {
         parent = parent.parent;
       }
       if (parent == null) {
-        console.log("Unused for", this.useCheckDuration, "seconds:");
-        console.log(this.inception);
+        console.debug("Unused for", this.useCheckDuration, "seconds:");
+        console.debug(this.inception);
         this.useCheckDuration *= 2;
         this.useCheckDelay = delay(
           this.useCheckDuration,
           this.checkUnused.bind(this)
         );
       } else {
-        console.log("On graph", this.inception);
+        console.debug("On graph", this.inception);
         this.useCheckDelay = null;
         this.useCheckDuration = 1;
       }

--- a/verreciel_js/scripts/components/scenenode.js
+++ b/verreciel_js/scripts/components/scenenode.js
@@ -121,13 +121,6 @@ class SceneNode {
     }
   }
 
-  whenTime() {
-    // assertArgs(arguments, 0);
-    for (let node of this.children) {
-      node.whenTime();
-    }
-  }
-
   whenSecond() {
     // assertArgs(arguments, 0);
     for (let node of this.children) {

--- a/verreciel_js/scripts/components/sceneport.js
+++ b/verreciel_js/scripts/components/sceneport.js
@@ -10,6 +10,15 @@ class ScenePort extends Empty {
     this.name = name;
     this.isEnabled = true;
     this.isPersistent = false;
+    verreciel.ghost.portsByName[name] = this;
+    let numberlessName = name.replace(/\d/g, "#");
+    if (name != numberlessName) {
+      this.numberlessName = numberlessName;
+      if (verreciel.ghost.portsByName[numberlessName] == null) {
+        verreciel.ghost.portsByName[numberlessName] = [];
+      }
+      verreciel.ghost.portsByName[numberlessName].push(this);
+    }
 
     this.trigger = new SceneTrigger(this, "port_" + name, 1, 1, 0);
     this.trigger.position.set(0, 0, -0.1);

--- a/verreciel_js/scripts/components/sceneport.js
+++ b/verreciel_js/scripts/components/sceneport.js
@@ -156,7 +156,7 @@ class ScenePort extends Empty {
     this.connection = port;
     this.connection.origin = this;
 
-    this.updateWire();
+    this.updateWire(true);
 
     this.wire.enable();
 
@@ -166,10 +166,11 @@ class ScenePort extends Empty {
     this.onConnect();
   }
 
-  updateWire() {
+  updateWire(reset = false) {
     this.wire.updateEnds(
       new THREE.Vector3(0, 0, 0),
-      this.convertPositionFromNode(new THREE.Vector3(0, 0, 0), this.connection)
+      this.convertPositionFromNode(new THREE.Vector3(0, 0, 0), this.connection),
+      reset
     );
   }
 

--- a/verreciel_js/scripts/components/sceneport.js
+++ b/verreciel_js/scripts/components/sceneport.js
@@ -157,9 +157,8 @@ class ScenePort extends Empty {
     this.connection = port;
     this.connection.origin = this;
 
-    this.updateWire(true);
-
     this.wire.enable();
+    this.updateWire(true);
 
     this.connection.host.onConnect();
     this.connection.onConnect();

--- a/verreciel_js/scripts/components/sceneport.js
+++ b/verreciel_js/scripts/components/sceneport.js
@@ -7,6 +7,7 @@ class ScenePort extends Empty {
     super();
 
     this.host = host;
+    this.name = name;
     this.isEnabled = true;
     this.isPersistent = false;
 

--- a/verreciel_js/scripts/components/sceneport.js
+++ b/verreciel_js/scripts/components/sceneport.js
@@ -2,15 +2,15 @@
 //  Copyright © 2017 XXIIVV. All rights reserved.
 
 class ScenePort extends Empty {
-  constructor(host, isPersistent = false) {
-    // assertArgs(arguments, 1);
+  constructor(host, name) {
+    assertArgs(arguments, 2);
     super();
 
     this.host = host;
     this.isEnabled = true;
-    this.isPersistent = isPersistent;
+    this.isPersistent = false;
 
-    this.trigger = new SceneTrigger(this, 1, 1);
+    this.trigger = new SceneTrigger(this, "port_" + name, 1, 1, 0);
     this.trigger.position.set(0, 0, -0.1);
     this.add(this.trigger);
 
@@ -435,25 +435,25 @@ class ScenePort extends Empty {
     super.onDisconnect();
     this.host.onDisconnect();
   }
+
+  static stripAllPorts(root) {
+    let ports = [];
+
+    function findPorts(node) {
+      if (node instanceof ScenePort) {
+        ports.push(node);
+      }
+      for (let child of node.children) {
+        findPorts(child);
+      }
+    }
+
+    findPorts(root);
+
+    for (let port of ports) {
+      if (port.isPersistent == false) {
+        port.strip();
+      }
+    }
+  }
 }
-
-ScenePort.stripAllPorts = function(root) {
-  let ports = [];
-
-  function findPorts(node) {
-    if (node instanceof ScenePort) {
-      ports.push(node);
-    }
-    for (let child of node.children) {
-      findPorts(child);
-    }
-  }
-
-  findPorts(root);
-
-  for (let port of ports) {
-    if (port.isPersistent == false) {
-      port.strip();
-    }
-  }
-};

--- a/verreciel_js/scripts/components/sceneportslot.js
+++ b/verreciel_js/scripts/components/sceneportslot.js
@@ -3,21 +3,22 @@
 
 class ScenePortSlot extends ScenePort {
   constructor(
-    host = new Empty(),
+    host,
+    name,
     align = Alignment.left,
     hasDetails = false,
     placeholder = "Empty"
   ) {
-    // assertArgs(arguments, 1);
-    super(host);
+    if (host == null) {
+      host = new Empty();
+    }
+
+    // assertArgs(arguments, 2);
+    super(host, name);
 
     this.placeholder = placeholder;
     this.hasDetails = hasDetails;
     this.uploadPercentage = 0;
-
-    this.trigger = new SceneTrigger(this, 1, 1);
-    this.trigger.position.set(0, 0, -0.1);
-    this.add(this.trigger);
 
     this.label = new SceneLabel(placeholder, 0.1, align, verreciel.grey);
     this.add(this.label);

--- a/verreciel_js/scripts/components/sceneportslot.js
+++ b/verreciel_js/scripts/components/sceneportslot.js
@@ -167,6 +167,7 @@ class ScenePortSlot extends ScenePort {
     this.uploadPercentage = 0;
     this.refresh();
     this.host.onUploadComplete();
+    verreciel.ghost.report(LogType.upload, this.name);
   }
 
   uploadCancel() {

--- a/verreciel_js/scripts/components/sceneportslot.js
+++ b/verreciel_js/scripts/components/sceneportslot.js
@@ -172,7 +172,10 @@ class ScenePortSlot extends ScenePort {
     this.uploadPercentage = 0;
     this.refresh();
     this.host.onUploadComplete();
-    verreciel.ghost.report(LogType.upload, this.name);
+    verreciel.ghost.report(
+      LogType.upload,
+      this.numberlessName == null ? this.name : this.numberlessName
+    );
   }
 
   uploadCancel() {

--- a/verreciel_js/scripts/components/sceneportslot.js
+++ b/verreciel_js/scripts/components/sceneportslot.js
@@ -162,8 +162,13 @@ class ScenePortSlot extends ScenePort {
   uploadComplete() {
     // assertArgs(arguments, 0);
     if (this.origin != null) {
+      let originHost = this.origin.host;
       this.addEvent(this.syphon());
+      if (originHost != null) {
+        originHost.onUploadComplete();
+      }
     }
+
     this.uploadPercentage = 0;
     this.refresh();
     this.host.onUploadComplete();

--- a/verreciel_js/scripts/components/scenetrigger.js
+++ b/verreciel_js/scripts/components/scenetrigger.js
@@ -43,7 +43,28 @@ class SceneTrigger extends SceneDrawNode {
     let result = this.host.touch(this.operation);
 
     if (result == true) {
-      verreciel.ghost.report(LogType.hit, this.name);
+      if (this.host instanceof ScenePort) {
+        if (
+          this.host.numberlessName != null &&
+          verreciel.ghost.portsByName[this.host.numberlessName].length > 1
+        ) {
+          verreciel.ghost.report(LogType.hit, {
+            from: "port",
+            numberlessName: this.host.numberlessName,
+            event: this.host.event == null ? null : this.host.event.code
+          });
+        } else {
+          verreciel.ghost.report(LogType.hit, {
+            from: "port",
+            name: this.host.name
+          });
+        }
+      } else {
+        verreciel.ghost.report(LogType.hit, {
+          from: "trigger",
+          name: this.name
+        });
+      }
     }
 
     return result;

--- a/verreciel_js/scripts/components/scenetrigger.js
+++ b/verreciel_js/scripts/components/scenetrigger.js
@@ -7,7 +7,7 @@ class SceneTrigger extends SceneDrawNode {
 
     super();
     this.name = name;
-    SceneTrigger.triggersByName[name] = this;
+    verreciel.ghost.triggersByName[name] = this;
     this.isEnabled = true;
     this.operation = operation;
     this.host = host;
@@ -43,7 +43,7 @@ class SceneTrigger extends SceneDrawNode {
     let result = this.host.touch(this.operation);
 
     if (result == true) {
-      console.log("hit:", this.name);
+      verreciel.ghost.report(LogType.hit, this.name);
     }
 
     return result;
@@ -68,12 +68,7 @@ class SceneTrigger extends SceneDrawNode {
       this.color = SceneTrigger.DEBUG_WHITE;
     }
   }
-
-  static autoTapTrigger(name) {
-    SceneTrigger.triggersByName[name].tap();
-  }
 }
 
 SceneTrigger.DEBUG_BLUE = new THREE.Vector4(0, 0, 1, 0.1);
 SceneTrigger.DEBUG_WHITE = new THREE.Vector4(1, 1, 1, 0.1);
-SceneTrigger.triggersByName = {};

--- a/verreciel_js/scripts/components/scenetrigger.js
+++ b/verreciel_js/scripts/components/scenetrigger.js
@@ -43,28 +43,10 @@ class SceneTrigger extends SceneDrawNode {
     let result = this.host.touch(this.operation);
 
     if (result == true) {
-      if (this.host instanceof ScenePort) {
-        if (
-          this.host.numberlessName != null &&
-          verreciel.ghost.portsByName[this.host.numberlessName].length > 1
-        ) {
-          verreciel.ghost.report(LogType.hit, {
-            from: "port",
-            numberlessName: this.host.numberlessName,
-            event: this.host.event == null ? null : this.host.event.code
-          });
-        } else {
-          verreciel.ghost.report(LogType.hit, {
-            from: "port",
-            name: this.host.name
-          });
-        }
-      } else {
-        verreciel.ghost.report(LogType.hit, {
-          from: "trigger",
-          name: this.name
-        });
-      }
+      verreciel.ghost.report(
+        LogType.hit,
+        verreciel.ghost.recordHitTarget(this)
+      );
     }
 
     return result;

--- a/verreciel_js/scripts/components/scenetrigger.js
+++ b/verreciel_js/scripts/components/scenetrigger.js
@@ -2,9 +2,12 @@
 //  Copyright © 2017 XXIIVV. All rights reserved.
 
 class SceneTrigger extends SceneDrawNode {
-  constructor(host, width, height, operation = 0) {
-    // assertArgs(arguments, 3);
+  constructor(host, name, width, height, operation) {
+    // assertArgs(arguments, 5);
+
     super();
+    this.name = name;
+    SceneTrigger.triggersByName[name] = this;
     this.isEnabled = true;
     this.operation = operation;
     this.host = host;
@@ -31,12 +34,19 @@ class SceneTrigger extends SceneDrawNode {
     super.makeElement();
   }
 
-  touch(id) {
+  tap() {
     // assertArgs(arguments, 1);
     if (this.isEnabled == false) {
       return false;
     }
-    return this.host.touch(this.operation);
+
+    let result = this.host.touch(this.operation);
+
+    if (result == true) {
+      console.log("hit:", this.name);
+    }
+
+    return result;
   }
 
   update() {
@@ -58,7 +68,12 @@ class SceneTrigger extends SceneDrawNode {
       this.color = SceneTrigger.DEBUG_WHITE;
     }
   }
+
+  static autoTapTrigger(name) {
+    SceneTrigger.triggersByName[name].tap();
+  }
 }
 
 SceneTrigger.DEBUG_BLUE = new THREE.Vector4(0, 0, 1, 0.1);
 SceneTrigger.DEBUG_WHITE = new THREE.Vector4(1, 1, 1, 0.1);
+SceneTrigger.triggersByName = {};

--- a/verreciel_js/scripts/components/scenewire.js
+++ b/verreciel_js/scripts/components/scenewire.js
@@ -10,27 +10,37 @@ class SceneWire extends Empty {
     this.host = host;
     this.endA = endA;
     this.endB = endB;
+    this.time = 0;
+    this.length = 0;
 
-    this.vertex1 = new THREE.Vector3(
+    this.baseline1 = new THREE.Vector3(
       this.endB.x * 0.2,
       this.endB.y * 0.2,
       this.endB.z * 0.2
     );
-    this.vertex2 = new THREE.Vector3(
+    this.baseline2 = new THREE.Vector3(
       this.endB.x * 0.4,
       this.endB.y * 0.4,
       this.endB.z * 0.4
     );
-    this.vertex3 = new THREE.Vector3(
+    this.baseline3 = new THREE.Vector3(
       this.endB.x * 0.6,
       this.endB.y * 0.6,
       this.endB.z * 0.6
     );
-    this.vertex4 = new THREE.Vector3(
+    this.baseline4 = new THREE.Vector3(
       this.endB.x * 0.8,
       this.endB.y * 0.8,
       this.endB.z * 0.8
     );
+
+    this.vertex1 = this.baseline1.clone();
+    this.vertex2 = this.baseline2.clone();
+    this.vertex3 = this.baseline3.clone();
+    this.vertex4 = this.baseline4.clone();
+
+    this.wiggle = new THREE.Vector3(0, 1, 0);
+    this.thrust = new THREE.Vector3();
 
     this.segment1 = new SceneLine([this.endA, this.vertex1], verreciel.cyan);
     this.segment2 = new SceneLine(
@@ -64,131 +74,79 @@ class SceneWire extends Empty {
     // assertArgs(arguments, 0);
     super.whenRenderer();
 
-    if (this.isEnabled == false || this.endB == null) {
-      return;
-    }
     if (
-      this.endA.x == this.endB.x &&
-      this.endA.y == this.endB.y &&
-      this.endA.z == this.endB.z
+      this.isEnabled == false ||
+      this.endB == null ||
+      this.endA.equals(this.endB)
     ) {
       return;
     }
 
+    this.thrust.y =
+      0.9 * this.thrust.y +
+      0.1 * -Math.sqrt(Math.abs(verreciel.thruster.actualSpeed));
     this.updateSegments();
   }
 
-  updateEnds(endA = new THREE.Vector3(), endB = new THREE.Vector3()) {
+  animate() {
+    let rand = Math.random();
+    this.time += rand * rand * rand;
+    if (
+      this.isEnabled == false ||
+      this.endB == null ||
+      this.endA.equals(this.endB)
+    ) {
+      return;
+    }
+    requestAnimationFrame(this.animate.bind(this));
+  }
+
+  updateEnds(
+    endA = new THREE.Vector3(),
+    endB = new THREE.Vector3(),
+    reset = true
+  ) {
     // assertArgs(arguments, 2);
     this.endA = endA;
     this.endB = endB;
+    this.length = this.endA.distanceTo(this.endB);
 
-    this.vertex1 = new THREE.Vector3(
-      this.endB.x * 0.2,
-      this.endB.y * 0.2,
-      this.endB.z * 0.2
-    );
-    this.vertex2 = new THREE.Vector3(
-      this.endB.x * 0.4,
-      this.endB.y * 0.4,
-      this.endB.z * 0.4
-    );
-    this.vertex3 = new THREE.Vector3(
-      this.endB.x * 0.6,
-      this.endB.y * 0.6,
-      this.endB.z * 0.6
-    );
-    this.vertex4 = new THREE.Vector3(
-      this.endB.x * 0.8,
-      this.endB.y * 0.8,
-      this.endB.z * 0.8
-    );
+    this.baseline1.copy(this.endB).multiplyScalar(0.2);
+    this.baseline2.copy(this.endB).multiplyScalar(0.4);
+    this.baseline3.copy(this.endB).multiplyScalar(0.6);
+    this.baseline4.copy(this.endB).multiplyScalar(0.8);
+
+    if (reset == true) {
+      this.phase = Math.random() * Math.PI * 2;
+      this.animate();
+    }
 
     this.updateSegments();
   }
 
   updateSegments() {
-    this.vertex1.x =
-      this.endB.x * 0.2 +
-      Math.cos(
-        (verreciel.game.time +
-          this.vertex1.x +
-          this.vertex1.y +
-          this.vertex1.z) /
-          20
-      ) *
-        0.05;
-    this.vertex2.x =
-      this.endB.x * 0.4 +
-      Math.cos(
-        (verreciel.game.time +
-          this.vertex2.x +
-          this.vertex2.y +
-          this.vertex2.z) /
-          20
-      ) *
-        0.08;
-    this.vertex3.x =
-      this.endB.x * 0.6 +
-      Math.cos(
-        (verreciel.game.time +
-          this.vertex3.x +
-          this.vertex3.y +
-          this.vertex3.z) /
-          20
-      ) *
-        0.08;
-    this.vertex4.x =
-      this.endB.x * 0.8 +
-      Math.cos(
-        (verreciel.game.time +
-          this.vertex4.x +
-          this.vertex4.y +
-          this.vertex4.z) /
-          20
-      ) *
-        0.05;
+    this.wiggle.y = Math.sin(this.time / (this.length * 20) + this.phase);
 
-    this.vertex1.y =
-      this.endB.y * 0.2 +
-      Math.sin(
-        (verreciel.game.time +
-          this.vertex1.x +
-          this.vertex1.y +
-          this.vertex1.z) /
-          20
-      ) *
-        0.05;
-    this.vertex2.y =
-      this.endB.y * 0.4 +
-      Math.sin(
-        (verreciel.game.time +
-          this.vertex2.x +
-          this.vertex2.y +
-          this.vertex2.z) /
-          20
-      ) *
-        0.08;
-    this.vertex3.y =
-      this.endB.y * 0.6 +
-      Math.sin(
-        (verreciel.game.time +
-          this.vertex3.x +
-          this.vertex3.y +
-          this.vertex3.z) /
-          20
-      ) *
-        0.08;
-    this.vertex4.y =
-      this.endB.y * 0.8 +
-      Math.sin(
-        (verreciel.game.time +
-          this.vertex4.x +
-          this.vertex4.y +
-          this.vertex4.z) /
-          20
-      ) *
-        0.05;
+    this.vertex1
+      .copy(this.wiggle)
+      .add(this.thrust)
+      .multiplyScalar(this.length * 0.05)
+      .add(this.baseline1);
+    this.vertex2
+      .copy(this.wiggle)
+      .add(this.thrust)
+      .multiplyScalar(this.length * 0.08)
+      .add(this.baseline2);
+    this.vertex3
+      .copy(this.wiggle)
+      .add(this.thrust)
+      .multiplyScalar(this.length * 0.08)
+      .add(this.baseline3);
+    this.vertex4
+      .copy(this.wiggle)
+      .add(this.thrust)
+      .multiplyScalar(this.length * 0.05)
+      .add(this.baseline4);
 
     this.segment1.updateVertices([this.endA, this.vertex1]);
     this.segment2.updateVertices([this.vertex1, this.vertex2]);

--- a/verreciel_js/scripts/core/capsule.js
+++ b/verreciel_js/scripts/core/capsule.js
@@ -20,6 +20,7 @@ class Capsule extends Empty {
     this.isFleeing = false;
     this.isReturning = false;
     this.panels = [];
+    this.previousLocations = [];
 
     this.mesh = new Empty();
     this.mesh.position.set(0, 0, 0);
@@ -273,6 +274,7 @@ class Capsule extends Empty {
   docked() {
     // assertArgs(arguments, 0);
     this.lastLocation = this.location;
+    this.previousLocations.push(this.location);
     if (this.isFleeing == true) {
       this.isFleeing = false;
       verreciel.thruster.unlock();
@@ -304,6 +306,9 @@ class Capsule extends Empty {
 
   flee() {
     // assertArgs(arguments, 0);
+    if (this.isDocked == true) {
+      this.undock();
+    }
     this.isFleeing = true;
     verreciel.thruster.lock();
     verreciel.thruster.speed = verreciel.thruster.maxSpeed();

--- a/verreciel_js/scripts/core/capsule.js
+++ b/verreciel_js/scripts/core/capsule.js
@@ -287,6 +287,7 @@ class Capsule extends Empty {
     verreciel.helmet.addPassive("Docked at " + this.location.name);
 
     verreciel.intercom.connectToLocation(this.location);
+    verreciel.ghost.report(LogType.docked, this.location.name);
   }
 
   undock() {

--- a/verreciel_js/scripts/core/capsule.js
+++ b/verreciel_js/scripts/core/capsule.js
@@ -8,7 +8,7 @@ class Capsule extends Empty {
     // assertArgs(arguments, 0);
     super();
 
-    console.log("^ Capsule | Init");
+    console.info("^ Capsule | Init");
 
     this.at = verreciel.universe.loiqe_spawn.at.clone();
     this.direction = 1;
@@ -75,7 +75,7 @@ class Capsule extends Empty {
   whenStart() {
     // assertArgs(arguments, 0);
     super.whenStart();
-    console.log("+ Capsule | Start");
+    console.info("+ Capsule | Start");
   }
 
   whenRenderer() {

--- a/verreciel_js/scripts/core/game.js
+++ b/verreciel_js/scripts/core/game.js
@@ -4,14 +4,14 @@
 class Game {
   constructor() {
     // assertArgs(arguments, 0);
-    console.log("^ Game | Init");
+    console.info("^ Game | Init");
     this.time = 0;
     this.gameSpeed = 1;
   }
 
   whenStart() {
     // assertArgs(arguments, 0);
-    console.log("+ Game | Start");
+    console.info("+ Game | Start");
     setTimeout(this.onTic.bind(this), 50);
     setTimeout(this.whenSecond.bind(this), 1000 / this.gameSpeed);
     this.load(this.state);
@@ -22,7 +22,7 @@ class Game {
     if (DEBUG_DONT_SAVE) {
       return;
     }
-    console.log("@ GAME     | Saved State to " + id);
+    console.info("@ GAME     | Saved State to " + id);
     for (let c of document.cookie.split(";")) {
       document.cookie = c
         .replace(/^ +/, "")
@@ -37,7 +37,7 @@ class Game {
     // assertArgs(arguments, 1);
     id = id == 20 ? 0 : id;
 
-    console.log("@ GAME     | Loaded State to " + id);
+    console.info("@ GAME     | Loaded State to " + id);
 
     for (let mission of verreciel.missions.story) {
       if (mission.id < id) {
@@ -57,7 +57,7 @@ class Game {
 
   erase() {
     // assertArgs(arguments, 0);
-    console.log("$ GAME     | Erase");
+    console.info("$ GAME     | Erase");
     localStorage.clear();
   }
 

--- a/verreciel_js/scripts/core/game.js
+++ b/verreciel_js/scripts/core/game.js
@@ -7,6 +7,9 @@ class Game {
     console.info("^ Game | Init");
     this.time = 0;
     this.gameSpeed = 1;
+    if (DEBUG_LOG_GHOST) {
+      this.gameSpeed = 5;
+    }
   }
 
   whenStart() {
@@ -14,6 +17,9 @@ class Game {
     console.info("+ Game | Start");
     setTimeout(this.onTic.bind(this), 50);
     setTimeout(this.whenSecond.bind(this), 1000 / this.gameSpeed);
+    if (DEBUG_LOG_GHOST) {
+      this.save(0);
+    }
     this.load(this.state);
   }
 

--- a/verreciel_js/scripts/core/game.js
+++ b/verreciel_js/scripts/core/game.js
@@ -6,13 +6,14 @@ class Game {
     // assertArgs(arguments, 0);
     console.log("^ Game | Init");
     this.time = 0;
+    this.gameSpeed = 1;
   }
 
   whenStart() {
     // assertArgs(arguments, 0);
     console.log("+ Game | Start");
     setTimeout(this.onTic.bind(this), 50);
-    setTimeout(this.whenSecond.bind(this), 1000);
+    setTimeout(this.whenSecond.bind(this), 1000 / this.gameSpeed);
     this.load(this.state);
   }
 
@@ -62,7 +63,7 @@ class Game {
 
   whenSecond() {
     // assertArgs(arguments, 0);
-    setTimeout(this.whenSecond.bind(this), 1000);
+    setTimeout(this.whenSecond.bind(this), 1000 / this.gameSpeed);
     verreciel.capsule.whenSecond();
     verreciel.missions.refresh();
   }
@@ -70,7 +71,6 @@ class Game {
   onTic() {
     // assertArgs(arguments, 0);
     setTimeout(this.onTic.bind(this), 50);
-    this.time += 1;
-    verreciel.space.whenTime();
+    this.time += this.gameSpeed;
   }
 }

--- a/verreciel_js/scripts/core/ghost.js
+++ b/verreciel_js/scripts/core/ghost.js
@@ -169,7 +169,7 @@ class Ghost extends Empty {
 
   whenStart() {
     super.whenStart();
-    delay((Math.random() * 4 + 6), this.blink.bind(this));
+    delay(Math.random() * 4 + 6, this.blink.bind(this));
     delay(0.2, this.waver.bind(this));
     if (DEBUG_LOG_GHOST) {
       this.ready = true;
@@ -178,9 +178,9 @@ class Ghost extends Empty {
         "media/walkthrough.json",
         function(data) {
           for (let record of JSON.parse(data)) {
-            this.salientEntries.push(
-              new LogEntry(record.type, record.data, record.skip)
-            );
+            let entry = new LogEntry(record.type, record.data, record.skip);
+            entry.index = record.index;
+            this.salientEntries.push(entry);
           }
           this.ready = true;
           this.pollForSummon();
@@ -216,12 +216,16 @@ class Ghost extends Empty {
   replay() {
     this.isReplaying = true;
     while (this.salientEntries[this.replayIndex].skip == true) {
-      console.log("SKIP", this.salientEntries[this.replayIndex]);
+      console.log(
+        "SKIP",
+        this.replayIndex,
+        this.salientEntries[this.replayIndex].toString()
+      );
       this.replayIndex++;
     }
     this.currentEntry = this.salientEntries[this.replayIndex];
     if (this.currentEntry.type == LogType.hit) {
-      console.log("HIT", this.currentEntry);
+      console.log("HIT", this.replayIndex, this.currentEntry.toString());
       let target = this.resolveHitTarget(this.currentEntry.data);
       this.wanderTo(
         target,
@@ -236,7 +240,7 @@ class Ghost extends Empty {
         }.bind(this)
       );
     } else {
-      console.log("WAIT", this.currentEntry.toString());
+      console.log("WAIT", this.replayIndex, this.currentEntry.toString());
     }
 
     if (this.entriesDuringTap.length > 0) {
@@ -404,20 +408,20 @@ class Ghost extends Empty {
             scale *
             this.danceAmplitude *
             0.2 *
-            Math.cos((verreciel.game.time / verreciel.game.gameSpeed) / 4),
+            Math.cos(verreciel.game.time / verreciel.game.gameSpeed / 4),
           0,
           scale *
             scale *
             this.danceAmplitude *
             0.2 *
-            Math.sin((verreciel.game.time / verreciel.game.gameSpeed) / 2)
+            Math.sin(verreciel.game.time / verreciel.game.gameSpeed / 2)
         );
       } else {
         if (this.danceAmplitude > 0) {
           this.danceAmplitude = 0;
           this.openEyes.opacity = 1;
           this.closedEyes.opacity = 0;
-          delay((Math.random() * 4 + 6), this.blink.bind(this));
+          delay(Math.random() * 4 + 6, this.blink.bind(this));
         }
         this.root.position.setNow(
           this.root.position.x * 0.8,
@@ -436,7 +440,7 @@ class Ghost extends Empty {
       this.entriesDuringTap.push(entry);
     } else if (this.isReplaying && entry.type != LogType.hit) {
       if (entry.toString() == this.currentEntry.toString()) {
-        console.log("Entry match:", entry.toString());
+        console.log("MATCH", this.replayIndex, entry.toString());
         this.replayIndex++;
         delay(0.5, this.replay.bind(this));
       }
@@ -527,7 +531,7 @@ setEnumValues(LogType, [
   "pilotAligned",
   "playerUnlock",
   "thrusterUnlock",
-  "upload",
+  "upload"
 ]);
 
 class LogEntry {
@@ -538,7 +542,7 @@ class LogEntry {
   }
 
   toString() {
-    let string = this.index + "\t" + this.type + "\t";
+    let string = this.type + "\t";
     if (this.data != null) {
       if (typeof this.data == "object") {
         for (let prop in this.data) {

--- a/verreciel_js/scripts/core/ghost.js
+++ b/verreciel_js/scripts/core/ghost.js
@@ -199,6 +199,9 @@ class Ghost extends Empty {
   }
 
   replay() {
+    if (this.replayIndex == this.salientEntries.length) {
+      this.isReplaying = false;
+    }
     if (this.isReplaying == false) {
       return;
     }

--- a/verreciel_js/scripts/core/ghost.js
+++ b/verreciel_js/scripts/core/ghost.js
@@ -74,6 +74,9 @@ class Ghost extends Empty {
     verreciel.animator.ease = Penner.easeInOutCubic;
     verreciel.capsule.show();
     verreciel.animator.commit();
+    this.isReplaying = false;
+    this.isWaiting = false;
+    verreciel.player.setIsPanoptic(false);
   }
 
   flicker() {
@@ -117,7 +120,7 @@ class Ghost extends Empty {
     verreciel.animator.completeAnimation("ghost");
 
     let distance = this.goalPosition.distanceTo(this.element.position);
-    let duration = 0.7 + 0.2 * distance;
+    let duration = 0.7 + 0.2 * distance / this.speed;
     verreciel.animator.begin("ghost");
     verreciel.animator.animationDuration = duration;
     verreciel.animator.ease = Penner.easeInOutCubic;
@@ -185,6 +188,7 @@ class Ghost extends Empty {
       playerRotation.equals(this.lastPlayerRotation) &&
       playerRotation.x > Math.PI / 4
     ) {
+      this.isReplaying = true;
       verreciel.player.setIsPanoptic(true);
       delay(0.5, this.appear.bind(this));
       delay(5, this.replay.bind(this));
@@ -195,7 +199,9 @@ class Ghost extends Empty {
   }
 
   replay() {
-    this.isReplaying = true;
+    if (this.isReplaying == false) {
+      return;
+    }
     while (this.salientEntries[this.replayIndex].skip == true) {
       /*
       console.log(
@@ -225,6 +231,9 @@ class Ghost extends Empty {
   }
 
   tap() {
+    if (this.isReplaying == false) {
+      return;
+    }
     let target = this.resolveHitTarget(this.currentEntry.data);
     let tapInPosition = this.element.position.clone().multiplyScalar(1.05);
     let tapOutPosition = this.element.position.clone();
@@ -429,19 +438,29 @@ class Ghost extends Empty {
       }
     }
 
-    let headGoalAngle = -Math.atan2(this.focus.z - this.position.z, this.focus.x - this.position.x);
+    let headGoalAngle = -Math.atan2(
+      this.focus.z - this.position.z,
+      this.focus.x - this.position.x
+    );
     let diffHeadRotY = sanitizeDiffAngle(headGoalAngle, this.headAngle);
     if (Math.abs(diffHeadRotY) > 0.001) {
-      this.headAngle += diffHeadRotY * 0.05;
+      this.headAngle += diffHeadRotY * 0.05 / this.speed;
     }
     this.head.rotation.y = this.headAngle;
 
     let faceAngle = this.face.rotation.y + this.headAngle;
-    let diffFaceRotY = sanitizeDiffAngle(verreciel.player.rotation.y, faceAngle);
+    let diffFaceRotY = sanitizeDiffAngle(
+      verreciel.player.rotation.y,
+      faceAngle
+    );
     if (Math.abs(diffFaceRotY) > 0.001) {
       faceAngle += diffFaceRotY * 0.3;
     }
-    this.face.rotation.setNow(this.face.rotation.x, faceAngle - this.headAngle, this.face.rotation.z);
+    this.face.rotation.setNow(
+      this.face.rotation.x,
+      faceAngle - this.headAngle,
+      this.face.rotation.z
+    );
   }
 
   report(type, data = null) {

--- a/verreciel_js/scripts/core/ghost.js
+++ b/verreciel_js/scripts/core/ghost.js
@@ -35,7 +35,7 @@ class Ghost extends Empty {
     if (DEBUG_LOG_GHOST == true) {
       document.onkeyup = function(event) {
         if (event.keyCode == 88) {
-          this.report(LogType.erratum);
+          this.report(LogType.mistake);
         }
       }.bind(this);
     }
@@ -351,9 +351,14 @@ class Ghost extends Empty {
       if (type == LogType.hit) {
         if (this.lastNonHit != null) {
           this.salientEntries.push(this.lastNonHit);
+          console.log(this.lastNonHit);
           this.lastNonHit = null;
         }
         this.salientEntries.push(entry);
+        console.log(entry);
+      } else if (type == LogType.mistake) {
+        this.salientEntries.push(entry);
+        console.log(entry);
       } else {
         this.lastNonHit = entry;
       }
@@ -376,12 +381,16 @@ setEnumValues(LogType, [
   "playerUnlock",
   "pilotAligned",
   "mission",
-  "quest"
+  "mistake"
 ]);
 
 class LogEntry {
   constructor(type, data) {
     this.type = type;
     this.data = data;
+  }
+
+  toString() {
+    return "> " + this.type + "\t" + this.data.toString();
   }
 }

--- a/verreciel_js/scripts/core/ghost.js
+++ b/verreciel_js/scripts/core/ghost.js
@@ -175,7 +175,7 @@ class Ghost extends Empty {
   }
 
   pollForSummon() {
-    if (verreciel.game.state > 0) {
+    if (verreciel.game.state > 0 && verreciel.numClicks == 0) {
       return;
     }
     let playerRotation = new THREE.Vector3(

--- a/verreciel_js/scripts/core/ghost.js
+++ b/verreciel_js/scripts/core/ghost.js
@@ -31,6 +31,14 @@ class Ghost extends Empty {
 
     this.openEyes.opacity = 1;
     this.closedEyes.opacity = 0;
+
+    if (DEBUG_LOG_GHOST == true) {
+      document.onkeyup = function(event) {
+        if (event.keyCode == 88) {
+          this.report(LogType.erratum);
+        }
+      }.bind(this);
+    }
   }
 
   appear() {

--- a/verreciel_js/scripts/core/ghost.js
+++ b/verreciel_js/scripts/core/ghost.js
@@ -1,0 +1,285 @@
+//  Created by Devine Lu Linvega.
+//  Copyright © 2017 XXIIVV. All rights reserved.
+
+class Ghost extends Empty {
+  constructor() {
+    super();
+
+    this.makeFuzz();
+    this.makeFace();
+    this.returnTimeout = null;
+
+    this.goalPosition = new THREE.Vector3();
+    this.faceRadius = 0.42;
+    this.faceRads = degToRad(45);
+    this.face.position.set(
+      this.faceRadius * Math.cos(this.faceRads),
+      0,
+      this.faceRadius * Math.sin(this.faceRads)
+    );
+
+    // this.hide();
+    this.triggersByName = {};
+    this.allEntries = [];
+    this.salientEntries = [];
+    this.lastNonHit = null;
+
+    this.openEyes.opacity = 1;
+    this.closedEyes.opacity = 0;
+  }
+
+  wanderTo(target, seconds = 2, callback = null) {
+    this.goalPosition
+      .copy(target.convertPositionToNode(new THREE.Vector3(), verreciel.root))
+      .multiply(new THREE.Vector3(0.7, 1, 0.7));
+    this.wanderToGoal(
+      seconds,
+      function() {
+        this.returnTimeout = setTimeout(this.returnToCenter.bind(this), 5000);
+        if (callback != null) {
+          callback();
+        }
+      }.bind(this)
+    );
+  }
+
+  wanderToGoal(seconds, callback) {
+    clearTimeout(this.returnTimeout);
+    this.faceRads = Math.atan2(
+      this.goalPosition.z - this.position.z,
+      this.goalPosition.x - this.position.x
+    );
+
+    verreciel.animator.begin();
+    verreciel.animator.animationDuration = Math.max(0.5, seconds / 4);
+    verreciel.animator.ease = Penner.easeInOutCubic;
+    this.face.position.set(
+      this.faceRadius * Math.cos(this.faceRads),
+      0,
+      this.faceRadius * Math.sin(this.faceRads)
+    );
+    verreciel.animator.commit();
+
+    verreciel.animator.begin();
+    verreciel.animator.animationDuration = seconds;
+    verreciel.animator.ease = Penner.easeInOutCubic;
+    this.position.set(
+      this.goalPosition.x,
+      this.goalPosition.y,
+      this.goalPosition.z
+    );
+    verreciel.animator.completionBlock = callback;
+    verreciel.animator.commit();
+  }
+
+  returnToCenter() {
+    this.goalPosition.set(0, 0, 0);
+    this.wanderToGoal(1.5, this.idle.bind(this));
+  }
+
+  idle() {
+    this.faceRads = degToRad(45);
+    verreciel.animator.begin();
+    verreciel.animator.animationDuration = 2;
+    verreciel.animator.delay = 0.25;
+    verreciel.animator.ease = Penner.easeInOutCubic;
+    this.face.position.set(
+      this.faceRadius * Math.cos(this.faceRads),
+      0,
+      this.faceRadius * Math.sin(this.faceRads)
+    );
+    verreciel.animator.commit();
+  }
+
+  whenStart() {
+    super.whenStart();
+    setTimeout(this.blink.bind(this), 1000 * (Math.random() * 4 + 6));
+    setTimeout(this.waver.bind(this), 200);
+  }
+
+  waver() {
+    setTimeout(this.waver.bind(this), 200);
+    for (let i = 0; i < this.fuzzVertices.length; i++) {
+      this.fuzzVertices[i].copy(this.fuzzBaseVertices[i]);
+      this.fuzzVertices[i].x += (Math.random() - 0.5) * 0.015;
+      this.fuzzVertices[i].z += (Math.random() - 0.5) * 0.015;
+    }
+    this.fuzz.updateVertices(this.fuzzVertices);
+  }
+
+  blink() {
+    this.openEyes.opacity = 0;
+    this.closedEyes.opacity = 1;
+    setTimeout(
+      function() {
+        this.openEyes.opacity = 1;
+        this.closedEyes.opacity = 0;
+
+        let nextTime = Math.random() > 0.8 ? 0.2 : Math.random() * 4 + 6;
+        setTimeout(this.blink.bind(this), 1000 * nextTime);
+      }.bind(this),
+      0.15 * 1000
+    );
+  }
+
+  makeFuzz() {
+    this.fuzzBaseVertices = [];
+    this.fuzzVertices = [];
+    let size1 = 0.84;
+    let size2 = 0.76;
+    let numLines = 80;
+    for (let i = 0; i < numLines; i++) {
+      let angle = degToRad(i * 360 / numLines);
+      this.fuzzBaseVertices.push(
+        new THREE.Vector3(Math.cos(angle) * size2, 0, Math.sin(angle) * size2)
+      );
+      this.fuzzBaseVertices.push(
+        new THREE.Vector3(Math.cos(angle) * size1, 0, Math.sin(angle) * size1)
+      );
+      this.fuzzVertices.push(new THREE.Vector3());
+      this.fuzzVertices.push(new THREE.Vector3());
+    }
+    this.fuzz = new SceneLine(this.fuzzVertices, verreciel.white);
+    this.add(this.fuzz);
+  }
+
+  makeFace() {
+    let center = new THREE.Vector3(0, 0, -0.14);
+    let faceVertices = [];
+    let openEyesVertices = [];
+    let closedEyesVertices = [];
+
+    faceVertices = faceVertices.concat(
+      this.makeCircle(9, 0.008, new THREE.Vector3(0.21, 0, 0.3).add(center))
+    );
+    faceVertices = faceVertices.concat(
+      this.makeCircle(9, 0.008, new THREE.Vector3(-0.21, 0, 0.3).add(center))
+    );
+    openEyesVertices = openEyesVertices.concat(
+      this.makeCircle(9, 0.03, new THREE.Vector3(0.21, 0, 0.2).add(center))
+    );
+    openEyesVertices = openEyesVertices.concat(
+      this.makeCircle(9, 0.03, new THREE.Vector3(-0.21, 0, 0.2).add(center))
+    );
+    closedEyesVertices.push(
+      new THREE.Vector3(-0.21 - 0.04, 0, 0.208).add(center),
+      new THREE.Vector3(-0.21 + 0.04, 0, 0.2).add(center)
+    );
+    closedEyesVertices.push(
+      new THREE.Vector3(0.21 - 0.04, 0, 0.2).add(center),
+      new THREE.Vector3(0.21 + 0.04, 0, 0.208).add(center)
+    );
+
+    let mouth1 = new THREE.Vector3(-1.0, 0.0, 0.0 * -0.6)
+      .multiplyScalar(0.03)
+      .add(center);
+    let mouth2 = new THREE.Vector3(-0.7, 0.0, -0.7 * -0.6)
+      .multiplyScalar(0.03)
+      .add(center);
+    let mouth3 = new THREE.Vector3(0.0, 0.0, -1.0 * -0.6)
+      .multiplyScalar(0.03)
+      .add(center);
+    let mouth4 = new THREE.Vector3(0.7, 0.0, -0.7 * -0.6)
+      .multiplyScalar(0.03)
+      .add(center);
+    let mouth5 = new THREE.Vector3(1.0, 0.0, 0.0 * -0.6)
+      .multiplyScalar(0.03)
+      .add(center);
+
+    let mouth = [
+      mouth1,
+      mouth2,
+      mouth2,
+      mouth3,
+      mouth3,
+      mouth4,
+      mouth4,
+      mouth5
+    ];
+    faceVertices = faceVertices.concat(mouth);
+
+    this.face = new SceneLine(faceVertices, verreciel.white);
+    this.add(this.face);
+    this.openEyes = new SceneLine(openEyesVertices, verreciel.white);
+    this.face.add(this.openEyes);
+    this.closedEyes = new SceneLine(closedEyesVertices, verreciel.white);
+    this.face.add(this.closedEyes);
+  }
+
+  makeCircle(numLines, radius, offset) {
+    let vertices = [];
+    let rads = degToRad(360 / numLines);
+
+    let angle = 0;
+    let axis = new THREE.Vector3(0, 1, 0);
+    let stylus = new THREE.Vector3(radius, 0, 0);
+    for (let i = 0; i < numLines; i++) {
+      vertices.push(stylus.clone().add(offset));
+      stylus.applyAxisAngle(axis, rads);
+      vertices.push(stylus.clone().add(offset));
+    }
+    return vertices;
+  }
+
+  whenRenderer() {
+    // assertArgs(arguments, 0);
+    super.whenRenderer();
+
+    let rotY = this.face.rotation.y;
+
+    let diffRotationY = sanitizeDiffAngle(verreciel.player.rotation.y, rotY);
+    if (Math.abs(diffRotationY) > 0.001) {
+      rotY += diffRotationY * 0.3;
+    }
+
+    let scale =
+      this.fuzz.element.scale.z * 0.5 +
+      (1 + verreciel.music.magnitude * 4) * 0.5;
+    this.fuzz.element.scale.x = scale;
+    this.fuzz.element.scale.z = scale;
+
+    this.face.rotation.setNow(this.face.rotation.x, rotY, this.face.rotation.z);
+  }
+
+  report(entry) {
+    if (this.isPlaying) {
+      // TODO: autopilot
+    } else if (DEBUG_LOG_GHOST == true) {
+      this.allEntries.push(entry);
+      if (entry.type == LogType.hit) {
+        if (this.lastNonHit != null) {
+          this.salientEntries.push(this.lastNonHit);
+          this.lastNonHit = null;
+        }
+        this.salientEntries.push(entry);
+      } else {
+        this.lastNonHit = entry;
+      }
+    }
+  }
+
+  tapTrigger(name) {
+    this.triggersByName[name].tap();
+  }
+}
+
+class LogType {}
+setEnumValues(LogType, [
+  "hit",
+  "install",
+  "upload",
+  "combination",
+  "docked",
+  "thrusterUnlock",
+  "playerUnlock",
+  "pilotAligned",
+  "mission",
+  "quest"
+]);
+
+class LogEntry {
+  constructor(type, data = null) {
+    this.type = type;
+    this.data = data;
+  }
+}

--- a/verreciel_js/scripts/core/ghost.js
+++ b/verreciel_js/scripts/core/ghost.js
@@ -26,7 +26,6 @@ class Ghost extends Empty {
     this.hide();
     this.triggersByName = {};
     this.portsByName = {};
-    this.allEntries = [];
     this.salientEntries = [];
     this.lastNonHit = null;
 
@@ -356,21 +355,29 @@ class Ghost extends Empty {
       // TODO: autopilot
     } else if (DEBUG_LOG_GHOST == true) {
       const entry = new LogEntry(type, data);
-      this.allEntries.push(entry);
       if (type == LogType.hit) {
         if (this.lastNonHit != null) {
-          this.salientEntries.push(this.lastNonHit);
-          console.log(Date.now() + "\t>\t" + this.lastNonHit.toString());
+          this.addEntry(this.lastNonHit);
           this.lastNonHit = null;
         }
-        this.salientEntries.push(entry);
-        console.log(Date.now() + "\t>\t" + entry.toString());
+        this.addEntry(entry);
       } else if (type == LogType.mistake || type == LogType.mission) {
-        this.salientEntries.push(entry);
-        console.log(Date.now() + "\t>\t" + entry.toString());
+        this.addEntry(entry);
       } else {
         this.lastNonHit = entry;
       }
+    }
+  }
+
+  addEntry(entry) {
+    entry.index = this.salientEntries.length;
+    this.salientEntries.push(entry);
+    console.log(">\t" + entry.toString());
+  }
+
+  rewindToEntry(index) {
+    if (index < this.salientEntries.length) {
+      this.salientEntries.splice(index + 1);
     }
   }
 
@@ -400,7 +407,7 @@ class LogEntry {
   }
 
   toString() {
-    let string = this.type + "\t";
+    let string = this.index + "\t" + this.type + "\t";
     if (this.data != null) {
       if (typeof this.data == "object") {
         for (let prop in this.data) {

--- a/verreciel_js/scripts/core/ghost.js
+++ b/verreciel_js/scripts/core/ghost.js
@@ -51,7 +51,7 @@ class Ghost extends Empty {
     this.hide();
     this.idle();
     verreciel.animator.begin();
-    verreciel.animator.animationDuration = 1;
+    verreciel.animator.animationDuration = 0.1;
     verreciel.animator.ease = Penner.easeInOutCubic;
     this.show();
     verreciel.capsule.show();
@@ -67,7 +67,7 @@ class Ghost extends Empty {
   onDisappear() {
     this.hide();
     verreciel.animator.begin();
-    verreciel.animator.animationDuration = 1;
+    verreciel.animator.animationDuration = 0.1;
     verreciel.animator.ease = Penner.easeInOutCubic;
     verreciel.capsule.show();
     verreciel.animator.commit();
@@ -320,9 +320,17 @@ class Ghost extends Empty {
         this.closedEyes.opacity = 1;
         this.danceAmplitude = Math.min(1, this.danceAmplitude + 0.005);
         this.root.position.setNow(
-          this.danceAmplitude * 0.4 * Math.cos(verreciel.game.time / 4),
+          scale *
+            scale *
+            this.danceAmplitude *
+            0.2 *
+            Math.cos(verreciel.game.time / 4),
           0,
-          this.danceAmplitude * 0.4 * Math.sin(verreciel.game.time / 2)
+          scale *
+            scale *
+            this.danceAmplitude *
+            0.2 *
+            Math.sin(verreciel.game.time / 2)
         );
       } else {
         if (this.danceAmplitude > 0) {

--- a/verreciel_js/scripts/core/ghost.js
+++ b/verreciel_js/scripts/core/ghost.js
@@ -25,6 +25,7 @@ class Ghost extends Empty {
 
     this.hide();
     this.triggersByName = {};
+    this.portsByName = {};
     this.allEntries = [];
     this.salientEntries = [];
     this.lastNonHit = null;
@@ -359,14 +360,14 @@ class Ghost extends Empty {
       if (type == LogType.hit) {
         if (this.lastNonHit != null) {
           this.salientEntries.push(this.lastNonHit);
-          console.log(this.lastNonHit);
+          console.log(Date.now() + "\t>\t" + this.lastNonHit.toString());
           this.lastNonHit = null;
         }
         this.salientEntries.push(entry);
-        console.log(entry);
-      } else if (type == LogType.mistake) {
+        console.log(Date.now() + "\t>\t" + entry.toString());
+      } else if (type == LogType.mistake || type == LogType.mission) {
         this.salientEntries.push(entry);
-        console.log(entry);
+        console.log(Date.now() + "\t>\t" + entry.toString());
       } else {
         this.lastNonHit = entry;
       }
@@ -380,16 +381,16 @@ class Ghost extends Empty {
 
 class LogType {}
 setEnumValues(LogType, [
-  "hit",
-  "install",
-  "upload",
   "combination",
   "docked",
-  "thrusterUnlock",
-  "playerUnlock",
-  "pilotAligned",
+  "hit",
+  "install",
   "mission",
-  "mistake"
+  "mistake",
+  "pilotAligned",
+  "playerUnlock",
+  "thrusterUnlock",
+  "upload"
 ]);
 
 class LogEntry {
@@ -399,6 +400,16 @@ class LogEntry {
   }
 
   toString() {
-    return "> " + this.type + "\t" + this.data.toString();
+    let string = this.type + "\t";
+    if (this.data != null) {
+      if (typeof this.data == "object") {
+        for (let prop in this.data) {
+          string += "(" + prop + ":" + this.data[prop] + ") ";
+        }
+      } else {
+        string += this.data.toString();
+      }
+    }
+    return string;
   }
 }

--- a/verreciel_js/scripts/core/ghost.js
+++ b/verreciel_js/scripts/core/ghost.js
@@ -334,12 +334,13 @@ class Ghost extends Empty {
     this.face.rotation.setNow(this.face.rotation.x, rotY, this.face.rotation.z);
   }
 
-  report(entry) {
+  report(type, data = null) {
     if (this.isPlaying) {
       // TODO: autopilot
     } else if (DEBUG_LOG_GHOST == true) {
+      const entry = new LogEntry(type, data);
       this.allEntries.push(entry);
-      if (entry.type == LogType.hit) {
+      if (type == LogType.hit) {
         if (this.lastNonHit != null) {
           this.salientEntries.push(this.lastNonHit);
           this.lastNonHit = null;
@@ -371,7 +372,7 @@ setEnumValues(LogType, [
 ]);
 
 class LogEntry {
-  constructor(type, data = null) {
+  constructor(type, data) {
     this.type = type;
     this.data = data;
   }

--- a/verreciel_js/scripts/core/ghost.js
+++ b/verreciel_js/scripts/core/ghost.js
@@ -16,6 +16,8 @@ class Ghost extends Empty {
     this.ready = false;
     this.replayIndex = 0;
     this.isTapping = false;
+    this.isWaiting = false;
+    this.speed = 1;
 
     this.lastPlayerRotation = null;
 
@@ -195,20 +197,23 @@ class Ghost extends Empty {
   replay() {
     this.isReplaying = true;
     while (this.salientEntries[this.replayIndex].skip == true) {
+      /*
       console.log(
         "SKIP",
         this.replayIndex,
         this.salientEntries[this.replayIndex].toString()
       );
+      */
       this.replayIndex++;
     }
     this.currentEntry = this.salientEntries[this.replayIndex];
     if (this.currentEntry.type == LogType.hit) {
-      console.log("HIT", this.replayIndex, this.currentEntry.toString());
+      // console.log("HIT", this.replayIndex, this.currentEntry.toString());
       let target = this.resolveHitTarget(this.currentEntry.data);
       this.wanderToTarget(target, this.tap.bind(this));
     } else {
-      console.log("WAIT", this.replayIndex, this.currentEntry.toString());
+      // console.log("WAIT", this.replayIndex, this.currentEntry.toString());
+      this.isWaiting = true;
     }
 
     if (this.entriesDuringTap.length > 0) {
@@ -378,6 +383,13 @@ class Ghost extends Empty {
     // assertArgs(arguments, 0);
     super.whenRenderer();
 
+    if (this.isWaiting == true) {
+      this.speed = this.speed * 0.999 + 10 * 0.001;
+    } else {
+      this.speed = this.speed * 0.5 + 1 * 0.5;
+    }
+    verreciel.game.gameSpeed = Math.floor(this.speed);
+
     let scale =
       this.fuzz.element.scale.z * 0.5 +
       (1 + verreciel.music.magnitude * 4) * 0.5;
@@ -415,8 +427,6 @@ class Ghost extends Empty {
           this.root.position.z * 0.8
         );
       }
-    } else {
-
     }
 
     let headGoalAngle = -Math.atan2(this.focus.z - this.position.z, this.focus.x - this.position.x);
@@ -440,7 +450,8 @@ class Ghost extends Empty {
       this.entriesDuringTap.push(entry);
     } else if (this.isReplaying && entry.type != LogType.hit) {
       if (entry.toString() == this.currentEntry.toString()) {
-        console.log("MATCH", this.replayIndex, entry.toString());
+        this.isWaiting = false;
+        // console.log("MATCH", this.replayIndex, entry.toString());
         this.replayIndex++;
         delay(0.5, this.replay.bind(this));
       }
@@ -462,7 +473,7 @@ class Ghost extends Empty {
   addEntry(entry) {
     entry.index = this.salientEntries.length;
     this.salientEntries.push(entry);
-    console.log(">\t" + entry.toString());
+    // console.log(">\t" + entry.toString());
   }
 
   rewindToEntry(index) {

--- a/verreciel_js/scripts/core/ghost.js
+++ b/verreciel_js/scripts/core/ghost.js
@@ -10,6 +10,7 @@ class Ghost extends Empty {
     this.makeFuzz();
     this.makeFace();
     this.returnTimeout = null;
+    this.flickerTimeoutnull;
     this.idling = true;
     this.danceAmplitude = 0;
 
@@ -30,6 +31,52 @@ class Ghost extends Empty {
 
     this.openEyes.opacity = 1;
     this.closedEyes.opacity = 0;
+  }
+
+  appear() {
+    this.flicker();
+    setTimeout(this.stopFlickering.bind(this), 700);
+    setTimeout(this.onAppear.bind(this), 2000);
+  }
+
+  onAppear() {
+    this.hide();
+    this.idle();
+    verreciel.animator.begin();
+    verreciel.animator.animationDuration = 1;
+    verreciel.animator.ease = Penner.easeInOutCubic;
+    this.show();
+    verreciel.capsule.show();
+    verreciel.animator.commit();
+  }
+
+  disappear() {
+    this.flicker();
+    setTimeout(this.stopFlickering.bind(this), 700);
+    setTimeout(this.onDisappear.bind(this), 2000);
+  }
+
+  onDisappear() {
+    this.hide();
+    verreciel.animator.begin();
+    verreciel.animator.animationDuration = 1;
+    verreciel.animator.ease = Penner.easeInOutCubic;
+    verreciel.capsule.show();
+    verreciel.animator.commit();
+  }
+
+  flicker() {
+    this.flickerTimeout = setTimeout(this.flicker.bind(this), 50);
+    verreciel.capsule.opacity = Math.random();
+    if (this.opacity != 0) {
+      this.opacity = verreciel.capsule.opacity;
+    }
+  }
+
+  stopFlickering() {
+    clearTimeout(this.flickerTimeout);
+    verreciel.capsule.hide();
+    this.hide();
   }
 
   wanderTo(target, seconds = 2, callback = null) {

--- a/verreciel_js/scripts/core/helmet.js
+++ b/verreciel_js/scripts/core/helmet.js
@@ -16,7 +16,9 @@ class Helmet extends Empty {
     let hamZ = ham.position.z;
 
     Object.defineProperty(ham.position, "x", {
-      get: function() { return hamX; },
+      get: function() {
+        return hamX;
+      },
       set: function(value) {
         console.log("x");
         console.log(getStackTrace());
@@ -28,12 +30,14 @@ class Helmet extends Empty {
           node.position.__xProperty.percent
         );
         console.log("");
-        return hamX = value;
+        return (hamX = value);
       }
     });
 
     Object.defineProperty(ham.position, "y", {
-      get: function() { return hamY; },
+      get: function() {
+        return hamY;
+      },
       set: function(value) {
         console.log("y");
         console.log(getStackTrace());
@@ -45,13 +49,14 @@ class Helmet extends Empty {
           node.position.__yProperty.percent
         );
         console.log("");
-        return hamY = value;
+        return (hamY = value);
       }
     });
 
-
     Object.defineProperty(ham.position, "z", {
-      get: function() { return hamZ; },
+      get: function() {
+        return hamZ;
+      },
       set: function(value) {
         console.log("z");
         console.log(getStackTrace());
@@ -63,7 +68,7 @@ class Helmet extends Empty {
           node.position.__zProperty.percent
         );
         console.log("");
-        return hamZ = value;
+        return (hamZ = value);
       }
     });
     */
@@ -363,5 +368,13 @@ class Helmet extends Empty {
     this.warningFlag = "";
     this.warningString = "";
     this.warningLabel.updateText("");
+  }
+
+  resizeText(size) {
+    this.textSize = size;
+    this.leftHandLabel.updateScale(this.textSize);
+    this.messageLabel.updateScale(this.textSize);
+    this.passiveLabel.updateScale(this.textSize);
+    this.rightHandLabel.updateScale(this.textSize);
   }
 }

--- a/verreciel_js/scripts/core/helmet.js
+++ b/verreciel_js/scripts/core/helmet.js
@@ -20,16 +20,16 @@ class Helmet extends Empty {
         return hamX;
       },
       set: function(value) {
-        console.log("x");
-        console.log(getStackTrace());
-        console.log(
+        console.debug("x");
+        console.debug(getStackTrace());
+        console.debug(
           value,
           node.position.__xProperty.animation != null,
           node.position.__xProperty.from,
           node.position.__xProperty.to,
           node.position.__xProperty.percent
         );
-        console.log("");
+        console.debug("");
         return (hamX = value);
       }
     });
@@ -39,16 +39,16 @@ class Helmet extends Empty {
         return hamY;
       },
       set: function(value) {
-        console.log("y");
-        console.log(getStackTrace());
-        console.log(
+        console.debug("y");
+        console.debug(getStackTrace());
+        console.debug(
           value,
           node.position.__yProperty.animation != null,
           node.position.__yProperty.from,
           node.position.__yProperty.to,
           node.position.__yProperty.percent
         );
-        console.log("");
+        console.debug("");
         return (hamY = value);
       }
     });
@@ -58,22 +58,22 @@ class Helmet extends Empty {
         return hamZ;
       },
       set: function(value) {
-        console.log("z");
-        console.log(getStackTrace());
-        console.log(
+        console.debug("z");
+        console.debug(getStackTrace());
+        console.debug(
           value,
           node.position.__zProperty.animation != null,
           node.position.__zProperty.from,
           node.position.__zProperty.to,
           node.position.__zProperty.percent
         );
-        console.log("");
+        console.debug("");
         return (hamZ = value);
       }
     });
     */
 
-    console.log("^ Helmet | Init");
+    console.info("^ Helmet | Init");
 
     this.canAlign = false;
     this.visor = new Empty();
@@ -217,7 +217,7 @@ class Helmet extends Empty {
   whenStart() {
     // assertArgs(arguments, 0);
     super.whenStart();
-    console.log("+ Helmet | Start");
+    console.info("+ Helmet | Start");
   }
 
   whenRenderer() {

--- a/verreciel_js/scripts/core/music.js
+++ b/verreciel_js/scripts/core/music.js
@@ -26,7 +26,7 @@ class Music {
       return;
     }
     this.ambience = name;
-    if (this.track == null) {
+    if (this.track == null || this.track.name != name) {
       this.playAmbience();
     }
   }

--- a/verreciel_js/scripts/core/music.js
+++ b/verreciel_js/scripts/core/music.js
@@ -47,7 +47,10 @@ class Music {
       return;
     }
     this.ambience = name;
-    if (this.track == null || this.track.name != name) {
+    if (
+      this.track == null ||
+      (this.track.role == "ambience" && this.track.name != name)
+    ) {
       this.playAmbience();
     }
   }
@@ -57,7 +60,10 @@ class Music {
       return;
     }
     this.record = name;
-    if (this.track == null) {
+    if (
+      this.track == null ||
+      (this.track.role == "record" && this.track.name != name)
+    ) {
       this.playRecord();
     }
   }

--- a/verreciel_js/scripts/core/music.js
+++ b/verreciel_js/scripts/core/music.js
@@ -12,7 +12,7 @@ class Music {
 
   playEffect(name) {
     // assertArgs(arguments, 1);
-    // console.log("Effect: ",name);
+    // console.info("Effect: ",name);
     this.fetchAudio(
       name,
       "effect",
@@ -66,9 +66,9 @@ class Music {
       );
       this.track.currentTime = 0;
       if (DEBUG_NO_MUSIC) {
-        console.log(role, ":", name, "(off by debug)");
+        console.info(role, ":", name, "(off by debug)");
       } else {
-        console.log(role, ":", name);
+        console.info(role, ":", name);
         this.track.play();
       }
     }

--- a/verreciel_js/scripts/core/music.js
+++ b/verreciel_js/scripts/core/music.js
@@ -30,13 +30,16 @@ class Music {
   playEffect(name) {
     // assertArgs(arguments, 1);
     // console.info("Effect: ",name);
-    this.fetchTrack(
+    let track = this.fetchTrack(
       name,
       "effect",
       "media/audio/effect/" + name + ".ogg",
       false,
       false
-    ).play();
+    );
+    if (verreciel.game.time - track.lastTimePlayed > 5) {
+      track.play();
+    }
   }
 
   setAmbience(name) {
@@ -109,6 +112,7 @@ class Track {
     this.role = role;
     this.audio.src = src;
     this.audio.loop = loop;
+    this.lastTimePlayed = 0;
     if (analyze) {
       this.node = verreciel.music.context.createMediaElementSource(this.audio);
     }
@@ -123,6 +127,7 @@ class Track {
   }
 
   play() {
+    this.lastTimePlayed = verreciel.game.time;
     if (this.node != null) {
       this.node.connect(verreciel.music.analyser);
     }

--- a/verreciel_js/scripts/core/music.js
+++ b/verreciel_js/scripts/core/music.js
@@ -76,6 +76,10 @@ class Music {
     this.switchAudio("ambience", this.ambience);
   }
 
+  isPlayingRecord() {
+    return this.track != null && this.track.role == "record";
+  }
+
   switchAudio(role, name) {
     if (this.track != null) {
       if (this.track.name == name) {

--- a/verreciel_js/scripts/core/music.js
+++ b/verreciel_js/scripts/core/music.js
@@ -98,7 +98,6 @@ class Music {
     if (!(audioId in this.trackCatalog)) {
       this.trackCatalog[audioId] = new Track(name, role, src, loop, analyze);
     }
-    this.trackCatalog[audioId].currentTime = 0;
     return this.trackCatalog[audioId];
   }
 }
@@ -127,6 +126,7 @@ class Track {
     if (this.node != null) {
       this.node.connect(verreciel.music.analyser);
     }
+    this.audio.currentTime = 0;
     this.audio.play();
   }
 

--- a/verreciel_js/scripts/core/player.js
+++ b/verreciel_js/scripts/core/player.js
@@ -80,6 +80,7 @@ class Player extends Empty {
         this.rotation.y,
         verreciel.helmet.rotation.z
       );
+      verreciel.ghost.report(LogType.playerUnlock, deg);
     }.bind(this);
     verreciel.animator.commit();
 
@@ -101,11 +102,15 @@ class Player extends Empty {
       this.rotation.x = degToRad(90);
       verreciel.space.structuresRoot.position.y = 5;
       verreciel.helmet.position.y = -3;
+      verreciel.above.opacity = 0;
+      verreciel.below.opacity = 0;
     } else {
       this.position.y = 0;
       this.rotation.x = degToRad(0);
       verreciel.space.structuresRoot.position.y = 0;
       verreciel.helmet.position.y = 0;
+      verreciel.above.opacity = 1;
+      verreciel.below.opacity = 1;
     }
 
     verreciel.animator.completionBlock = function() {

--- a/verreciel_js/scripts/core/player.js
+++ b/verreciel_js/scripts/core/player.js
@@ -6,7 +6,7 @@ class Player extends Empty {
     // assertArgs(arguments, 0);
     super();
 
-    console.log("^ Player | Init");
+    console.info("^ Player | Init");
 
     this.canAlign = true;
     this.isLocked = false;
@@ -17,20 +17,8 @@ class Player extends Empty {
     this.accelY = 0;
     this.isPanoptic = false;
 
-    this.port = new ScenePort(this);
+    this.port = new ScenePort(this, "player");
     this.port.enable();
-
-    // TODO: spacewalk
-    /*
-    this.trigger = new SceneTrigger(this, 2, 0.75);
-    this.trigger.position.set(0, 0.9, -1.01);
-    this.trigger.hide();
-    this.add(this.trigger);
-    
-    this.triggerLabel = new SceneLabel("return to capsule", 0.03, Alignment.center, verreciel.red);
-    this.triggerLabel.position.set(0,0,0);
-    this.trigger.add(this.triggerLabel);
-    */
 
     this.element.add(verreciel.camera);
   }
@@ -38,7 +26,7 @@ class Player extends Empty {
   whenStart() {
     // assertArgs(arguments, 0);
     super.whenStart();
-    console.log("+ Player | Start");
+    console.info("+ Player | Start");
   }
 
   whenRenderer() {

--- a/verreciel_js/scripts/core/player.js
+++ b/verreciel_js/scripts/core/player.js
@@ -15,6 +15,7 @@ class Player extends Empty {
     this.position.set(0, 0, 0);
     this.accelX = 0;
     this.accelY = 0;
+    this.isPanoptic = false;
 
     this.port = new ScenePort(this);
     this.port.enable();
@@ -30,6 +31,8 @@ class Player extends Empty {
     this.triggerLabel.position.set(0,0,0);
     this.trigger.add(this.triggerLabel);
     */
+
+    this.element.add(verreciel.camera);
   }
 
   whenStart() {
@@ -43,7 +46,9 @@ class Player extends Empty {
     super.whenRenderer();
 
     if (!this.isLocked) {
-      this.rotation.x += this.accelX;
+      if (!this.isPanoptic) {
+        this.rotation.x += this.accelX;
+      }
       this.rotation.y += this.accelY;
 
       this.rotation.x = Math.max(
@@ -62,9 +67,6 @@ class Player extends Empty {
         this.accelY = 0; //if it gets too small just drop to zero
       }
     }
-
-    this.element.add(verreciel.camera);
-    // verreciel.camera.position.z = 8;
   }
 
   lookAt(deg = 0) {
@@ -94,6 +96,35 @@ class Player extends Empty {
     verreciel.animator.commit();
 
     this.releaseHandle();
+  }
+
+  setIsPanoptic(value) {
+    if (this.isPanoptic == value) {
+      return;
+    }
+    this.isPanoptic = value;
+
+    verreciel.animator.begin();
+    verreciel.animator.animationDuration = 2;
+    verreciel.animator.ease = Penner.easeInOutQuart;
+    this.isLocked = true;
+    if (this.isPanoptic) {
+      this.position.y = -5;
+      this.rotation.x = degToRad(90);
+      verreciel.space.structuresRoot.position.y = 5;
+      verreciel.helmet.position.y = -3;
+    } else {
+      this.position.y = 0;
+      this.rotation.x = degToRad(0);
+      verreciel.space.structuresRoot.position.y = 0;
+      verreciel.helmet.position.y = 0;
+    }
+
+    verreciel.animator.completionBlock = function() {
+      this.isLocked = false;
+      verreciel.helmet.resizeText(this.isPanoptic == true ? 0.04 : 0.025);
+    }.bind(this);
+    verreciel.animator.commit();
   }
 
   eject() {

--- a/verreciel_js/scripts/core/player.js
+++ b/verreciel_js/scripts/core/player.js
@@ -68,18 +68,22 @@ class Player extends Empty {
     verreciel.animator.begin("look at");
     verreciel.animator.animationDuration = 2.5;
 
-    this.position.set(0, 0, 0); // ?
     this.rotation.y = degToRad(deg);
-    verreciel.helmet.position.set(0, 0, 0); // ?
-    verreciel.helmet.rotation.y = degToRad(deg);
+    if (!this.isPanoptic) {
+      this.position.set(0, 0, 0); // ?
+      verreciel.helmet.position.set(0, 0, 0); // ?
+      verreciel.helmet.rotation.y = degToRad(deg);
+    }
 
     verreciel.animator.completionBlock = function() {
       this.isLocked = false;
-      verreciel.helmet.rotation.setNow(
-        verreciel.helmet.rotation.x,
-        this.rotation.y,
-        verreciel.helmet.rotation.z
-      );
+      if (!this.isPanoptic) {
+        verreciel.helmet.rotation.setNow(
+          verreciel.helmet.rotation.x,
+          this.rotation.y,
+          verreciel.helmet.rotation.z
+        );
+      }
       verreciel.ghost.report(LogType.playerUnlock, deg);
     }.bind(this);
     verreciel.animator.commit();

--- a/verreciel_js/scripts/core/player.js
+++ b/verreciel_js/scripts/core/player.js
@@ -101,6 +101,7 @@ class Player extends Empty {
       this.position.y = -5;
       this.rotation.x = degToRad(90);
       verreciel.space.structuresRoot.position.y = 5;
+      verreciel.space.structuresRoot.opacity = 0.2;
       verreciel.helmet.position.y = -3;
       verreciel.above.opacity = 0;
       verreciel.below.opacity = 0;
@@ -108,6 +109,7 @@ class Player extends Empty {
       this.position.y = 0;
       this.rotation.x = degToRad(0);
       verreciel.space.structuresRoot.position.y = 0;
+      verreciel.space.structuresRoot.opacity = 1;
       verreciel.helmet.position.y = 0;
       verreciel.above.opacity = 1;
       verreciel.below.opacity = 1;

--- a/verreciel_js/scripts/core/space.js
+++ b/verreciel_js/scripts/core/space.js
@@ -3,7 +3,7 @@
 
 class Space extends Empty {
   constructor() {
-    assertArgs(arguments, 0);
+    // assertArgs(arguments, 0);
     super();
 
     console.log("^ Space | Init");
@@ -26,7 +26,7 @@ class Space extends Empty {
   }
 
   whenStart() {
-    assertArgs(arguments, 0);
+    // assertArgs(arguments, 0);
     super.whenStart();
     console.log("+ Space | Start");
   }
@@ -34,7 +34,7 @@ class Space extends Empty {
   // Space Color
 
   onSystemEnter(system) {
-    assertArgs(arguments, 1);
+    // assertArgs(arguments, 1);
     verreciel.capsule.system = system;
     switch (system) {
       case Systems.valen:
@@ -74,14 +74,12 @@ class Space extends Empty {
   // Instances
 
   startInstance(location) {
-    assertArgs(arguments, 1);
+    // assertArgs(arguments, 1);
     this.structuresRoot.add(location.structure);
   }
 
-  whenTime() {
-    assertArgs(arguments, 0);
-    super.whenTime();
-
+  whenRenderer() {
+    super.whenRenderer();
     if (
       verreciel.capsule.isDockedAtLocation(verreciel.universe.close) == true
     ) {
@@ -180,7 +178,7 @@ Space.unit = 19;
 
 class StarCluster extends Empty {
   constructor() {
-    assertArgs(arguments, 0);
+    // assertArgs(arguments, 0);
     super();
     this.mesh = new SceneLine([], verreciel.white);
     this.add(this.mesh);
@@ -233,7 +231,7 @@ class StarCluster extends Empty {
   }
 
   whenRenderer() {
-    assertArgs(arguments, 0);
+    // assertArgs(arguments, 0);
     var starSpeed = verreciel.thruster.actualSpeed;
     if (
       verreciel.capsule.isDocked == false &&

--- a/verreciel_js/scripts/core/space.js
+++ b/verreciel_js/scripts/core/space.js
@@ -6,7 +6,7 @@ class Space extends Empty {
     // assertArgs(arguments, 0);
     super();
 
-    console.log("^ Space | Init");
+    console.info("^ Space | Init");
 
     this.targetSpaceColor = new THREE.Color(0, 0, 0);
     this.currentSpaceColor = new THREE.Color(0, 0, 0);
@@ -28,7 +28,7 @@ class Space extends Empty {
   whenStart() {
     // assertArgs(arguments, 0);
     super.whenStart();
-    console.log("+ Space | Start");
+    console.info("+ Space | Start");
   }
 
   // Space Color

--- a/verreciel_js/scripts/core/universe.js
+++ b/verreciel_js/scripts/core/universe.js
@@ -5,7 +5,7 @@ class Universe extends Empty {
   constructor() {
     // assertArgs(arguments, 0);
     super();
-    console.log("^ Universe | Init");
+    console.info("^ Universe | Init");
 
     this.eventView = verreciel.radar.eventView;
 
@@ -81,7 +81,7 @@ class Universe extends Empty {
 
   whenStart() {
     super.whenStart();
-    console.log("+ Universe | Start");
+    console.info("+ Universe | Start");
     this.connectPaths();
   }
 

--- a/verreciel_js/scripts/core/verreciel.js
+++ b/verreciel_js/scripts/core/verreciel.js
@@ -26,6 +26,7 @@ class Verreciel {
     this.fps = 40;
     this.camera = new THREE.PerspectiveCamera(105, 1, 0.0001, 10000);
     this.raycaster = new THREE.Raycaster();
+    this.numClicks = 0;
     this.scene = new THREE.Scene();
     this.scene.background = new THREE.Color(0, 0, 0);
     this.renderer = new THREE.WebGLRenderer({ antialias: false });
@@ -209,6 +210,7 @@ class Verreciel {
       if (hits.length > 0 && this.ghost.isReplaying) {
         this.ghost.disappear();
       } else {
+        this.numClicks++;
         hits.sort(this.hasShortestDistance);
         for (let hit of hits) {
           if (hit.object.node.tap()) {

--- a/verreciel_js/scripts/core/verreciel.js
+++ b/verreciel_js/scripts/core/verreciel.js
@@ -39,6 +39,7 @@ class Verreciel {
     this.music = new Music();
 
     this.animator = new Animator();
+    this.ghost = new Ghost();
 
     // Collections
     this.items = new Items();
@@ -100,7 +101,9 @@ class Verreciel {
     this.root.add(this.helmet);
     this.root.add(this.capsule);
     this.root.add(this.space);
+    this.root.add(this.ghost);
 
+    this.ghost.whenStart();
     this.universe.whenStart();
     this.player.whenStart();
     this.helmet.whenStart();

--- a/verreciel_js/scripts/core/verreciel.js
+++ b/verreciel_js/scripts/core/verreciel.js
@@ -203,7 +203,7 @@ class Verreciel {
       let hits = this.getHits().filter(this.isEnabledTrigger);
       hits.sort(this.hasShortestDistance);
       for (let hit of hits) {
-        if (hit.object.node.touch(0)) {
+        if (hit.object.node.tap()) {
           break;
         }
       }

--- a/verreciel_js/scripts/core/verreciel.js
+++ b/verreciel_js/scripts/core/verreciel.js
@@ -132,8 +132,10 @@ class Verreciel {
     }
     let frameTime = Date.now();
 
-    let framesElapsed =
-      (frameTime - this.lastFrameTime) / 1000 * this.fps * this.game.gameSpeed;
+    let framesElapsed = Math.min(
+      100,
+      (frameTime - this.lastFrameTime) / 1000 * this.fps * this.game.gameSpeed
+    );
     if (framesElapsed > 1) {
       this.lastFrameTime = frameTime;
       for (let i = 0; i < framesElapsed; i++) {

--- a/verreciel_js/scripts/core/verreciel.js
+++ b/verreciel_js/scripts/core/verreciel.js
@@ -129,10 +129,13 @@ class Verreciel {
     }
     let frameTime = Date.now();
 
-    let framesElapsed = (frameTime - this.lastFrameTime) / 1000 * this.fps;
+    let framesElapsed =
+      (frameTime - this.lastFrameTime) / 1000 * this.fps * this.game.gameSpeed;
     if (framesElapsed > 1) {
       this.lastFrameTime = frameTime;
-      this.root.whenRenderer();
+      for (let i = 0; i < framesElapsed; i++) {
+        this.root.whenRenderer();
+      }
       this.helmet.updatePortWires();
       this.renderer.render(this.scene, this.camera);
     }

--- a/verreciel_js/scripts/core/verreciel.js
+++ b/verreciel_js/scripts/core/verreciel.js
@@ -206,10 +206,14 @@ class Verreciel {
     if (!this.mouseMoved) {
       event.preventDefault();
       let hits = this.getHits().filter(this.isEnabledTrigger);
-      hits.sort(this.hasShortestDistance);
-      for (let hit of hits) {
-        if (hit.object.node.tap()) {
-          break;
+      if (hits.length > 0 && this.ghost.isReplaying) {
+        this.ghost.disappear();
+      } else {
+        hits.sort(this.hasShortestDistance);
+        for (let hit of hits) {
+          if (hit.object.node.tap()) {
+            break;
+          }
         }
       }
     }

--- a/verreciel_js/scripts/locations/bank.js
+++ b/verreciel_js/scripts/locations/bank.js
@@ -8,12 +8,12 @@ class LocationBank extends Location {
 
     this.details = "storage";
 
-    this.port1 = new ScenePortSlot(this);
-    this.port2 = new ScenePortSlot(this);
-    this.port3 = new ScenePortSlot(this);
-    this.port4 = new ScenePortSlot(this);
-    this.port5 = new ScenePortSlot(this);
-    this.port6 = new ScenePortSlot(this);
+    this.port1 = new ScenePortSlot(this, this.code + "_slot_1");
+    this.port2 = new ScenePortSlot(this, this.code + "_slot_2");
+    this.port3 = new ScenePortSlot(this, this.code + "_slot_3");
+    this.port4 = new ScenePortSlot(this, this.code + "_slot_4");
+    this.port5 = new ScenePortSlot(this, this.code + "_slot_5");
+    this.port6 = new ScenePortSlot(this, this.code + "_slot_6");
 
     this.port1.enable();
     this.port2.enable();

--- a/verreciel_js/scripts/locations/harvest.js
+++ b/verreciel_js/scripts/locations/harvest.js
@@ -29,7 +29,7 @@ class LocationHarvest extends Location {
 
   generate() {
     // assertArgs(arguments, 0);
-    setTimeout(this.generate.bind(this), 1000);
+    delay(1, this.generate.bind(this));
 
     if (this.port == null) {
       return;

--- a/verreciel_js/scripts/locations/harvest.js
+++ b/verreciel_js/scripts/locations/harvest.js
@@ -30,6 +30,7 @@ class LocationHarvest extends Location {
     // assertArgs(arguments, 0);
     super.whenStart();
     this.port.addEvent(this.grows);
+    verreciel.ghost.report(LogType.harvest, this.grows.code);
   }
 
   generate() {
@@ -55,7 +56,10 @@ class LocationHarvest extends Location {
     } else {
       this.refresh();
       this.generationCountdown = 0;
-      this.port.addEvent(this.grows);
+      if (!this.port.hasEvent(this.grows)) {
+        this.port.addEvent(this.grows);
+        verreciel.ghost.report(LogType.harvest, this.grows.code);
+      }
       this.structure.update();
     }
 

--- a/verreciel_js/scripts/locations/harvest.js
+++ b/verreciel_js/scripts/locations/harvest.js
@@ -15,7 +15,12 @@ class LocationHarvest extends Location {
     this.generationCountdown = 0;
     this.generationRate = 200;
 
-    this.port = new ScenePortSlot(this, Alignment.center, true);
+    this.port = new ScenePortSlot(
+      this,
+      this.code + "_" + this.grows.name,
+      Alignment.center,
+      false
+    );
     this.port.enable();
 
     this.generate();

--- a/verreciel_js/scripts/locations/horadric.js
+++ b/verreciel_js/scripts/locations/horadric.js
@@ -16,8 +16,20 @@ class LocationHoradric extends Location {
     // assertArgs(arguments, 0);
     let newPanel = new Panel();
 
-    this.inPort1 = new ScenePortSlot(this, Alignment.center, false, "In");
-    this.inPort2 = new ScenePortSlot(this, Alignment.center, false, "In");
+    this.inPort1 = new ScenePortSlot(
+      this,
+      this.code + "_input_1",
+      Alignment.center,
+      false,
+      "In"
+    );
+    this.inPort2 = new ScenePortSlot(
+      this,
+      this.code + "_input_2",
+      Alignment.center,
+      false,
+      "In"
+    );
 
     this.inPort1.label.position.set(0, 0.5, 0);
     this.inPort2.label.position.set(0, 0.5, 0);
@@ -28,7 +40,13 @@ class LocationHoradric extends Location {
     this.inPort1.position.set(0.6, 0.6, 0);
     this.inPort2.position.set(-0.6, 0.6, 0);
 
-    this.outPort = new ScenePortSlot(this, Alignment.center, false, "");
+    this.outPort = new ScenePortSlot(
+      this,
+      this.code + "_output_1",
+      Alignment.center,
+      false,
+      ""
+    );
     this.outPort.position.set(0, -0.8, 0);
     this.outPort.label.position.set(0, -0.4, 0);
     this.outPort.label.updateText("Out");

--- a/verreciel_js/scripts/locations/horadric.js
+++ b/verreciel_js/scripts/locations/horadric.js
@@ -238,7 +238,7 @@ class LocationHoradric extends Location {
     verreciel.music.playEffect("beep2");
     verreciel.ghost.report(
       LogType.combination,
-      this.combinationRecipe.result.name // TODO: should've been code
+      this.combinationRecipe.result.code
     );
   }
 }

--- a/verreciel_js/scripts/locations/horadric.js
+++ b/verreciel_js/scripts/locations/horadric.js
@@ -236,6 +236,10 @@ class LocationHoradric extends Location {
 
     this.refresh();
     verreciel.music.playEffect("beep2");
+    verreciel.ghost.report(
+      LogType.combination,
+      this.combinationRecipe.result.name
+    );
   }
 }
 

--- a/verreciel_js/scripts/locations/horadric.js
+++ b/verreciel_js/scripts/locations/horadric.js
@@ -238,7 +238,7 @@ class LocationHoradric extends Location {
     verreciel.music.playEffect("beep2");
     verreciel.ghost.report(
       LogType.combination,
-      this.combinationRecipe.result.name
+      this.combinationRecipe.result.name // TODO: should've been code
     );
   }
 }

--- a/verreciel_js/scripts/locations/location.js
+++ b/verreciel_js/scripts/locations/location.js
@@ -29,13 +29,10 @@ class Location extends Event {
 
     this.structure.addHost(this);
     this.icon.addHost(this);
-  }
 
-  get panel() {
-    if (this._panel === undefined) {
-      this._panel = this.makePanel();
-    }
-    return this._panel;
+    let trigger = new SceneTrigger(this, "location_" + this.code, 1, 1, 0);
+    trigger.position.set(0, 0, -0.1);
+    this.add(trigger);
   }
 
   makePanel() {
@@ -47,7 +44,7 @@ class Location extends Event {
   whenStart() {
     // assertArgs(arguments, 0);
     super.whenStart();
-
+    this.panel = this.makePanel();
     this.position.set(this.at.x, this.at.y, 0);
     this.distance = distanceBetweenTwoPoints(verreciel.capsule.at, this.at);
     this.angle = this.calculateAngle();

--- a/verreciel_js/scripts/locations/portal.js
+++ b/verreciel_js/scripts/locations/portal.js
@@ -19,14 +19,14 @@ class LocationPortal extends Location {
       Alignment.center,
       verreciel.grey
     );
-    this.pilotPort = new ScenePort(this);
+    this.pilotPort = new ScenePort(this, this.code + "_pilot");
     this.pilotLabel = new SceneLabel(
       "pilot",
       0.1,
       Alignment.center,
       verreciel.grey
     );
-    this.thrusterPort = new ScenePort(this);
+    this.thrusterPort = new ScenePort(this, this.code + "_thruster");
     this.thrusterLabel = new SceneLabel(
       "thruster",
       0.08,

--- a/verreciel_js/scripts/locations/satellite.js
+++ b/verreciel_js/scripts/locations/satellite.js
@@ -17,7 +17,12 @@ class LocationSatellite extends Location {
     this.mapRequirement = mapRequirement;
     this.message = message;
 
-    this.port = new ScenePortSlot(this, Alignment.center, true);
+    this.port = new ScenePortSlot(
+      this,
+      this.code + "_" + item.name,
+      Alignment.center,
+      true
+    );
     this.port.position.set(0, -0.4, 0);
     this.port.addEvent(item);
     this.port.enable();

--- a/verreciel_js/scripts/locations/star.js
+++ b/verreciel_js/scripts/locations/star.js
@@ -6,7 +6,7 @@ class LocationStar extends Location {
     // assertArgs(arguments, 3);
     super(name, system, at, new IconStar(), new StructureStar());
     this.isComplete = false;
-    this.masterPort = new ScenePort(this);
+    this.masterPort = new ScenePort(this, this.code);
   }
 
   makePanel() {
@@ -21,7 +21,13 @@ class LocationStar extends Location {
     );
     newPanel.add(requirementLabel);
 
-    this.button = new SceneButton(this, "install", 1, 1);
+    this.button = new SceneButton(
+      this,
+      this.code + "_install",
+      "install",
+      1,
+      1
+    );
     this.button.position.set(0, -1, 0);
     newPanel.add(this.button);
 

--- a/verreciel_js/scripts/locations/star.js
+++ b/verreciel_js/scripts/locations/star.js
@@ -53,7 +53,9 @@ class LocationStar extends Location {
 
   sightUpdate() {
     // assertArgs(arguments, 0);
-    let radiation = (1 - this.distance / 0.7) / 0.6;
+
+    let radiation =
+      this.isComplete == true ? 0 : (1 - this.distance / 0.7) / 0.6;
 
     if (verreciel.capsule.hasShield() == false) {
       if (radiation > 1 && verreciel.capsule.isFleeing == false) {

--- a/verreciel_js/scripts/locations/station.js
+++ b/verreciel_js/scripts/locations/station.js
@@ -39,11 +39,11 @@ class LocationStation extends Location {
     );
     newPanel.add(requirementLabel);
 
-    this.button = new SceneButton(this, "install", 1);
+    this.button = new SceneButton(this, this.code + "_install", "install", 1);
     this.button.position.set(0, -1, 0);
     newPanel.add(this.button);
 
-    this.port = new ScenePortSlot(this);
+    this.port = new ScenePortSlot(this, this.code);
     this.port.position.set(0, -0.2, 0);
     newPanel.add(this.port);
 

--- a/verreciel_js/scripts/locations/trade.js
+++ b/verreciel_js/scripts/locations/trade.js
@@ -12,10 +12,10 @@ class LocationTrade extends Location {
     this.mapRequirement = mapRequirement;
     this.isTradeAccepted = false;
 
-    this.wantPort = new ScenePortSlot(this);
+    this.wantPort = new ScenePortSlot(this, this.code + "_want");
     this.wantPort.addRequirement(want);
     this.wantPort.label.updateText("EMPTY", verreciel.red);
-    this.givePort = new ScenePortSlot(this);
+    this.givePort = new ScenePortSlot(this, this.code + "_give");
     this.givePort.addEvent(give);
   }
 

--- a/verreciel_js/scripts/objects/event.js
+++ b/verreciel_js/scripts/objects/event.js
@@ -21,17 +21,6 @@ class Event extends Empty {
     this.color = color;
   }
 
-  // MARK: Basic -
-
-  whenStart() {
-    // assertArgs(arguments, 0);
-    super.whenStart();
-
-    let trigger = new SceneTrigger(this, 1, 1);
-    trigger.position.set(0, 0, -0.1);
-    this.add(trigger);
-  }
-
   // MARK: Radar -
 
   update() {

--- a/verreciel_js/scripts/objects/item.js
+++ b/verreciel_js/scripts/objects/item.js
@@ -30,7 +30,7 @@ class Item extends Event {
       null,
       other.details,
       other.isQuest,
-      null
+      other.code
     );
   }
 }

--- a/verreciel_js/scripts/objects/item.js
+++ b/verreciel_js/scripts/objects/item.js
@@ -21,16 +21,16 @@ class Item extends Event {
       new ConsoleData(this.details)
     ]);
   }
-}
 
-Item.like = function(other) {
-  // assertArgs(arguments, 1);
-  return new Item(
-    other.name,
-    other.type,
-    null,
-    other.details,
-    other.isQuest,
-    null
-  );
-};
+  static like(other) {
+    // assertArgs(arguments, 1);
+    return new Item(
+      other.name,
+      other.type,
+      null,
+      other.details,
+      other.isQuest,
+      null
+    );
+  }
+}

--- a/verreciel_js/scripts/objects/mission.js
+++ b/verreciel_js/scripts/objects/mission.js
@@ -40,6 +40,7 @@ class Mission {
       }
     }
     this.isCompleted = true;
+    verreciel.ghost.report(LogType.mission, this.id);
   }
 
   prompt() {

--- a/verreciel_js/scripts/objects/quest.js
+++ b/verreciel_js/scripts/objects/quest.js
@@ -30,6 +30,7 @@ class Quest {
       return;
     }
     this.isCompleted = true;
+    verreciel.ghost.report(LogType.quest, this.name);
     this.result();
   }
 }

--- a/verreciel_js/scripts/objects/quest.js
+++ b/verreciel_js/scripts/objects/quest.js
@@ -30,7 +30,6 @@ class Quest {
       return;
     }
     this.isCompleted = true;
-    verreciel.ghost.report(LogType.quest, this.name);
     this.result();
   }
 }

--- a/verreciel_js/scripts/panels/mainpanels/battery.js
+++ b/verreciel_js/scripts/panels/mainpanels/battery.js
@@ -4,61 +4,72 @@
 class Battery extends MainPanel {
   constructor() {
     // assertArgs(arguments, 0);
-    super();
+    super("battery");
 
-    this.name = "battery";
     this.details = "powers systems";
 
     // Cells
 
     let distance = 0.3;
 
-    this.cellPort1 = new ScenePortSlot(this, Alignment.right);
+    this.cellPort1 = new ScenePortSlot(
+      this,
+      "battery_slot_cell1",
+      Alignment.right
+    );
     this.cellPort1.position.set(-distance, Templates.lineSpacing, 0);
     this.cellPort1.enable();
     this.mainNode.add(this.cellPort1);
 
-    this.cellPort2 = new ScenePortSlot(this, Alignment.right);
+    this.cellPort2 = new ScenePortSlot(
+      this,
+      "battery_slot_cell2",
+      Alignment.right
+    );
     this.cellPort2.position.set(-distance, 0, 0);
     this.cellPort2.enable();
     this.mainNode.add(this.cellPort2);
 
-    this.cellPort3 = new ScenePortSlot(this, Alignment.right);
+    this.cellPort3 = new ScenePortSlot(
+      this,
+      "battery_slot_cell3",
+      Alignment.right
+    );
     this.cellPort3.position.set(-distance, -Templates.lineSpacing, 0);
     this.cellPort3.enable();
     this.mainNode.add(this.cellPort3);
 
     // Systems
 
-    this.enigmaPort = new ScenePort(this);
+    this.enigmaPort = new ScenePort(this, "battery_slot_shield");
     this.enigmaPort.position.set(distance, 2 * Templates.lineSpacing, 0);
     this.enigmaLabel = new SceneLabel("shield", 0.1, Alignment.left);
     this.enigmaLabel.position.set(0.3, 0, 0);
     this.enigmaPort.add(this.enigmaLabel);
     this.mainNode.add(this.enigmaPort);
 
-    this.thrusterPort = new ScenePort(this);
+    this.thrusterPort = new ScenePort(this, "battery_slot_thruster");
     this.thrusterPort.position.set(distance, Templates.lineSpacing, 0);
     this.thrusterLabel = new SceneLabel("thruster", 0.1, Alignment.left);
     this.thrusterLabel.position.set(0.3, 0, 0);
     this.thrusterPort.add(this.thrusterLabel);
     this.mainNode.add(this.thrusterPort);
 
-    this.radioPort = new ScenePort(this);
+    this.radioPort = new ScenePort(this, "battery_slot_radio");
     this.radioPort.position.set(distance, 0, 0);
     this.radioLabel = new SceneLabel("radio", 0.1, Alignment.left);
     this.radioLabel.position.set(0.3, 0, 0);
     this.radioPort.add(this.radioLabel);
     this.mainNode.add(this.radioPort);
 
-    this.navPort = new ScenePort(this);
+    this.navPort = new ScenePort(this, "battery_slot_cloak");
     this.navPort.position.set(distance, -Templates.lineSpacing, 0);
     this.navLabel = new SceneLabel("cloak", 0.1, Alignment.left);
     this.navLabel.position.set(0.3, 0, 0);
     this.navPort.add(this.navLabel);
     this.mainNode.add(this.navPort);
 
-    this.shieldPort = new ScenePort(this);
+    this.shieldPort = new ScenePort(this, "battery_slot_oxygen");
     this.shieldPort.position.set(distance, 2 * -Templates.lineSpacing, 0);
     this.shieldLabel = new SceneLabel("oxygen", 0.1, Alignment.left);
     this.shieldLabel.position.set(0.3, 0, 0);

--- a/verreciel_js/scripts/panels/mainpanels/cargo.js
+++ b/verreciel_js/scripts/panels/mainpanels/cargo.js
@@ -357,6 +357,7 @@ class Cargo extends MainPanel {
     }
     this.uploadPercentage = 0;
     this.refresh();
+    verreciel.ghost.report(LogType.upload, this.name);
   }
 
   uploadCancel() {

--- a/verreciel_js/scripts/panels/mainpanels/cargo.js
+++ b/verreciel_js/scripts/panels/mainpanels/cargo.js
@@ -4,11 +4,10 @@
 class Cargo extends MainPanel {
   constructor() {
     // assertArgs(arguments, 0);
-    super();
+    super("cargo");
 
     this.cargohold = new CargoHold();
 
-    this.name = "cargo";
     this.details = "stores items";
     this.port.event = this.cargohold;
     this.uploadPercentage = 0;

--- a/verreciel_js/scripts/panels/mainpanels/console.js
+++ b/verreciel_js/scripts/panels/mainpanels/console.js
@@ -4,18 +4,17 @@
 class Console extends MainPanel {
   constructor() {
     // assertArgs(arguments, 0);
-    super();
+    super("console");
 
     this.lines = [
-      new ConsoleLine(),
-      new ConsoleLine(),
-      new ConsoleLine(),
-      new ConsoleLine(),
-      new ConsoleLine(),
-      new ConsoleLine()
+      new ConsoleLine(1),
+      new ConsoleLine(2),
+      new ConsoleLine(3),
+      new ConsoleLine(4),
+      new ConsoleLine(5),
+      new ConsoleLine(6)
     ];
 
-    this.name = "console";
     this.details = "inspects events";
 
     this.lines[0].position.set(
@@ -170,11 +169,11 @@ class Console extends MainPanel {
 }
 
 class ConsoleLine extends Empty {
-  constructor(data = null) {
+  constructor(index) {
     // assertArgs(arguments, 0);
     super();
 
-    this.port = new ScenePortRedirect(this);
+    this.port = new ScenePortRedirect(this, "console_line_" + index);
     this.port.position.set(0, 0, 0);
     this.port.hide();
     this.add(this.port);
@@ -191,11 +190,6 @@ class ConsoleLine extends Empty {
     );
     this.detailsLabel.position.set(3.2, 0, 0);
     this.add(this.detailsLabel);
-
-    // Missing, but surely this is correct?
-    if (data != null) {
-      this.updateLine(data);
-    }
   }
 
   updateData(data) {

--- a/verreciel_js/scripts/panels/mainpanels/console.js
+++ b/verreciel_js/scripts/panels/mainpanels/console.js
@@ -89,11 +89,6 @@ class Console extends MainPanel {
     this.inject(this.defaultPayload());
   }
 
-  whenTime() {
-    // assertArgs(arguments, 0);
-    super.whenTime();
-  }
-
   clear() {
     // assertArgs(arguments, 0);
     for (let line of this.lines) {

--- a/verreciel_js/scripts/panels/mainpanels/hatch.js
+++ b/verreciel_js/scripts/panels/mainpanels/hatch.js
@@ -9,7 +9,7 @@ class Hatch extends MainPanel {
     this.outline = new Empty();
     this.count = 0;
 
-    this.details = "jetisons items";
+    this.details = "jettisons items";
     this.pendingErase = false;
 
     this.mainNode.add(

--- a/verreciel_js/scripts/panels/mainpanels/hatch.js
+++ b/verreciel_js/scripts/panels/mainpanels/hatch.js
@@ -4,12 +4,11 @@
 class Hatch extends MainPanel {
   constructor() {
     // assertArgs(arguments, 0);
-    super();
+    super("hatch");
 
     this.outline = new Empty();
     this.count = 0;
 
-    this.name = "hatch";
     this.details = "jetisons items";
     this.pendingErase = false;
 
@@ -63,7 +62,7 @@ class Hatch extends MainPanel {
 
     // Trigger
 
-    this.mainNode.add(new SceneTrigger(this, 2, 2));
+    this.mainNode.add(new SceneTrigger(this, "hatch_jettison", 2, 2, 0));
 
     this.detailsLabel.updateText("empty", verreciel.grey);
   }
@@ -126,7 +125,7 @@ class Hatch extends MainPanel {
         this.detailsLabel.updateText("error", verreciel.red);
         this.outline.updateChildrenColors(verreciel.red);
       } else {
-        this.detailsLabel.updateText("jetison", verreciel.cyan);
+        this.detailsLabel.updateText("jettison", verreciel.cyan);
         this.outline.updateChildrenColors(verreciel.cyan);
       }
     } else {

--- a/verreciel_js/scripts/panels/mainpanels/intercom.js
+++ b/verreciel_js/scripts/panels/mainpanels/intercom.js
@@ -215,6 +215,8 @@ class Intercom extends MainPanel {
     this.locationPanel.position.set(0, 0, -0.5);
     this.locationPanel.hide();
 
+    ScenePort.stripAllPorts(this);
+
     verreciel.animator.completionBlock = function() {
       // this.defaultPanel.position.set(0,0,-0.5);
 

--- a/verreciel_js/scripts/panels/mainpanels/intercom.js
+++ b/verreciel_js/scripts/panels/mainpanels/intercom.js
@@ -6,9 +6,8 @@ class Intercom extends MainPanel {
 
   constructor() {
     // assertArgs(arguments, 0);
-    super();
+    super("mission");
 
-    this.name = "mission";
     this.details = "displays informations";
 
     this.selector = new SceneLabel(">", 0.1, Alignment.left);

--- a/verreciel_js/scripts/panels/mainpanels/mainpanel.js
+++ b/verreciel_js/scripts/panels/mainpanels/mainpanel.js
@@ -2,9 +2,9 @@
 //  Copyright © 2017 XXIIVV. All rights reserved.
 
 class MainPanel extends Panel {
-  constructor() {
-    // assertArgs(arguments, 0);
-    super();
+  constructor(name) {
+    assertArgs(arguments, 1);
+    super(name);
 
     this.installNode = new Empty();
     this.installNode.position.set(0, 0, 0);
@@ -33,14 +33,13 @@ class MainPanel extends Panel {
     this.mainNode = new Empty();
     this.decals = new Empty();
 
-    this.name = "unknown";
     this.details = "unknown";
     this.root.position.set(0, 0, Templates.radius);
     this.root.add(this.mainNode);
     this.root.add(this.decals);
 
     // Header
-    this.port = new ScenePort(this);
+    this.port = new ScenePort(this, "mainpanel_" + this.name);
     this.port.position.set(0, 0.4, Templates.radius);
     this.nameLabel.position.set(0, 0, Templates.radius);
     this.header.add(this.port);

--- a/verreciel_js/scripts/panels/mainpanels/pilot.js
+++ b/verreciel_js/scripts/panels/mainpanels/pilot.js
@@ -9,6 +9,7 @@ class Pilot extends MainPanel {
     this.details = "aligns to locations";
     this.port.isPersistent = true;
     this.isAligned = false;
+    this.retargeting = false;
 
     this.targetDirectionIndicator = new Empty();
     this.targetDirectionIndicator.add(
@@ -82,6 +83,7 @@ class Pilot extends MainPanel {
     // assertArgs(arguments, 0);
     super.whenRenderer();
 
+    let lastTarget = this.target;
     this.target = null;
 
     if (verreciel.capsule.isFleeing == true) {
@@ -100,6 +102,10 @@ class Pilot extends MainPanel {
       this.target = verreciel.capsule.closestKnownLocation();
     } else if (this.port.isReceivingEventOfTypeLocation()) {
       this.target = this.port.origin.event;
+    }
+
+    if (lastTarget != this.target) {
+      this.retargeting = true;
     }
 
     if (this.target != null) {
@@ -129,9 +135,9 @@ class Pilot extends MainPanel {
       this.turnRight(this.target_align);
     }
 
-    let wasAligned = this.isAligned;
     this.isAligned = Math.abs(this.target.align) < 1;
-    if (this.isAligned == true && wasAligned == false) {
+    if (this.isAligned == true && this.retargeting == true) {
+      this.retargeting = false;
       verreciel.ghost.report(LogType.pilotAligned, this.target.name);
     }
 

--- a/verreciel_js/scripts/panels/mainpanels/pilot.js
+++ b/verreciel_js/scripts/panels/mainpanels/pilot.js
@@ -4,9 +4,8 @@
 class Pilot extends MainPanel {
   constructor() {
     // assertArgs(arguments, 0);
-    super();
+    super("pilot");
 
-    this.name = "pilot";
     this.details = "aligns to locations";
     this.port.isPersistent = true;
 

--- a/verreciel_js/scripts/panels/mainpanels/pilot.js
+++ b/verreciel_js/scripts/panels/mainpanels/pilot.js
@@ -8,6 +8,7 @@ class Pilot extends MainPanel {
 
     this.details = "aligns to locations";
     this.port.isPersistent = true;
+    this.isAligned = false;
 
     this.targetDirectionIndicator = new Empty();
     this.targetDirectionIndicator.add(
@@ -116,6 +117,12 @@ class Pilot extends MainPanel {
       this.turnLeft(this.target_align);
     } else {
       this.turnRight(this.target_align);
+    }
+
+    let wasAligned = this.isAligned;
+    this.isAligned = Math.abs(this.target.align) < 1;
+    if (this.isAligned == true && wasAligned == false) {
+      verreciel.ghost.report(LogType.pilotAligned, this.target.name);
     }
 
     this.animate();

--- a/verreciel_js/scripts/panels/mainpanels/pilot.js
+++ b/verreciel_js/scripts/panels/mainpanels/pilot.js
@@ -85,7 +85,17 @@ class Pilot extends MainPanel {
     this.target = null;
 
     if (verreciel.capsule.isFleeing == true) {
-      this.target = verreciel.capsule.lastLocation;
+      for (
+        let i = verreciel.capsule.previousLocations.length - 1;
+        i >= 0;
+        i--
+      ) {
+        let loc = verreciel.capsule.previousLocations[i];
+        if (loc.isComplete || !(loc instanceof LocationStar)) {
+          this.target = loc;
+          break;
+        }
+      }
     } else if (verreciel.capsule.isReturning == true) {
       this.target = verreciel.capsule.closestKnownLocation();
     } else if (this.port.isReceivingEventOfTypeLocation()) {

--- a/verreciel_js/scripts/panels/mainpanels/radar.js
+++ b/verreciel_js/scripts/panels/mainpanels/radar.js
@@ -4,7 +4,7 @@
 class Radar extends MainPanel {
   constructor() {
     // assertArgs(arguments, 0);
-    super();
+    super("radar");
 
     this.x = 0;
     this.z = 0;
@@ -13,7 +13,6 @@ class Radar extends MainPanel {
     this.eventPivot = new Empty();
     this.eventView = new Empty();
 
-    this.name = "radar";
     this.details = "displays locations";
     this.port.isPersistent = true;
 
@@ -228,7 +227,7 @@ class Radar extends MainPanel {
         newEvent.position.y == event.position.y &&
         event != newEvent
       ) {
-        console.log(
+        console.warn(
           "Overlapping event:",
           newEvent.name,
           "->",

--- a/verreciel_js/scripts/panels/mainpanels/thruster.js
+++ b/verreciel_js/scripts/panels/mainpanels/thruster.js
@@ -433,6 +433,7 @@ class Thruster extends MainPanel {
   unlock() {
     // assertArgs(arguments, 0);
     this.isLocked = false;
+    verreciel.ghost.report(LogType.thrusterUnlock);
   }
 
   // MARK: Custom -

--- a/verreciel_js/scripts/panels/mainpanels/thruster.js
+++ b/verreciel_js/scripts/panels/mainpanels/thruster.js
@@ -339,6 +339,13 @@ class Thruster extends MainPanel {
       verreciel.music.playEffect("click3");
       return true;
     } else if (id == 1) {
+      if (
+        (verreciel.pilot.target == null ||
+          verreciel.pilot.port.origin.host != verreciel.radar) &&
+        verreciel.pilot.isInstalled == true
+      ) {
+        return;
+      }
       this.speedUp();
       verreciel.music.playEffect("click4");
       return true;
@@ -772,7 +779,7 @@ class Thruster extends MainPanel {
     if (verreciel.capsule.location != null) {
       this.speed = 0;
     } else if (this.actualSpeed < 0.1) {
-      this.actualSpeed = 0.1;
+      this.actualSpeed = DEBUG_LOG_GHOST ? 0 : 0.1;
     }
 
     if (this.actualSpeed > 0) {

--- a/verreciel_js/scripts/panels/mainpanels/thruster.js
+++ b/verreciel_js/scripts/panels/mainpanels/thruster.js
@@ -6,7 +6,7 @@ class Thruster extends MainPanel {
 
   constructor() {
     // assertArgs(arguments, 0);
-    super();
+    super("thruster");
 
     this.interface_flight = new Empty();
     this.interface_cutlines = new Empty();
@@ -18,7 +18,6 @@ class Thruster extends MainPanel {
     this.isLocked = false;
     this.port.isPersistent = true;
 
-    this.name = "thruster";
     this.details = "moves the capsule";
 
     // Flight
@@ -288,7 +287,7 @@ class Thruster extends MainPanel {
 
     // Triggers
 
-    this.accelerate = new SceneTrigger(this, 1, 1, 1);
+    this.accelerate = new SceneTrigger(this, "thruster_accelerate", 1, 1, 1);
     this.accelerate.position.set(0, 0.5, 0);
     this.accelerate.add(
       new SceneLine(
@@ -303,7 +302,7 @@ class Thruster extends MainPanel {
       )
     );
 
-    this.decelerate = new SceneTrigger(this, 1, 1, 0);
+    this.decelerate = new SceneTrigger(this, "thruster_decelerate", 1, 1, 0);
     this.decelerate.position.set(0, -0.5, 0);
     this.decelerate.add(
       new SceneLine(
@@ -318,7 +317,7 @@ class Thruster extends MainPanel {
       )
     );
 
-    this.action = new SceneTrigger(this, 1.5, 1.5, 2);
+    this.action = new SceneTrigger(this, "thruster_action", 1.5, 1.5, 2);
 
     this.mainNode.add(this.accelerate);
     this.mainNode.add(this.decelerate);

--- a/verreciel_js/scripts/panels/monitors/complete.js
+++ b/verreciel_js/scripts/panels/monitors/complete.js
@@ -19,7 +19,7 @@ class Complete extends Monitor {
     this.nameLabel.updateText(
       verreciel.missions.currentMission.id +
         "/" +
-        verreciel.missions.story.length
+        (verreciel.missions.story.length - 1)
     );
   }
 }

--- a/verreciel_js/scripts/panels/panel.js
+++ b/verreciel_js/scripts/panels/panel.js
@@ -2,9 +2,10 @@
 //  Copyright © 2017 XXIIVV. All rights reserved.
 
 class Panel extends Empty {
-  constructor() {
+  constructor(name) {
     // assertArgs(arguments, 0);
     super();
+    this.name = name;
     this.isEnabled = false;
     this.root = new Empty();
     this.add(this.root);

--- a/verreciel_js/scripts/panels/panel.js
+++ b/verreciel_js/scripts/panels/panel.js
@@ -61,6 +61,7 @@ class Panel extends Empty {
     this.installPercentage = 0;
     this.isInstalled = true;
     verreciel.music.playEffect("beep2");
+    verreciel.ghost.report(LogType.install, this.name);
   }
 
   payload() {

--- a/verreciel_js/scripts/panels/widgets/enigma.js
+++ b/verreciel_js/scripts/panels/widgets/enigma.js
@@ -4,9 +4,8 @@
 class Enigma extends Widget {
   constructor() {
     // assertArgs(arguments, 0);
-    super();
+    super("enigma");
 
-    this.name = "enigma";
     this.details = "extra";
     this.requirement = ItemTypes.cypher;
     this.isPowered = function() {

--- a/verreciel_js/scripts/panels/widgets/nav.js
+++ b/verreciel_js/scripts/panels/widgets/nav.js
@@ -4,8 +4,7 @@
 class Nav extends Widget {
   constructor() {
     // assertArgs(arguments, 0);
-    super();
-    this.name = "map";
+    super("map");
     this.details = "disk drive";
     this.requirement = ItemTypes.map;
     this.isPowered = function() {

--- a/verreciel_js/scripts/panels/widgets/radio.js
+++ b/verreciel_js/scripts/panels/widgets/radio.js
@@ -63,6 +63,22 @@ class Radio extends Widget {
     verreciel.music.playAmbience();
   }
 
+  whenRenderer() {
+    super.whenRenderer();
+
+    if (
+      verreciel.music.track != null &&
+      verreciel.music.track.role == "record"
+    ) {
+      let scale = 1 + verreciel.music.magnitude * 10;
+      this.port.sprite_output.element.scale.x = scale;
+      this.port.sprite_output.element.scale.y = scale;
+    } else {
+      this.port.sprite_output.element.scale.x = 1;
+      this.port.sprite_output.element.scale.y = 1;
+    }
+  }
+
   onUploadComplete() {
     // assertArgs(arguments, 0);
     super.onUploadComplete();

--- a/verreciel_js/scripts/panels/widgets/radio.js
+++ b/verreciel_js/scripts/panels/widgets/radio.js
@@ -4,10 +4,9 @@
 class Radio extends Widget {
   constructor() {
     // assertArgs(arguments, 0);
-    super();
+    super("radio");
 
     this.seek = 0;
-    this.name = "radio";
     this.details = "format reader";
     this.requirement = ItemTypes.record;
     this.isPowered = function() {

--- a/verreciel_js/scripts/panels/widgets/radio.js
+++ b/verreciel_js/scripts/panels/widgets/radio.js
@@ -66,10 +66,7 @@ class Radio extends Widget {
   whenRenderer() {
     super.whenRenderer();
 
-    if (
-      verreciel.music.track != null &&
-      verreciel.music.track.role == "record"
-    ) {
+    if (verreciel.music.isPlayingRecord()) {
       let scale = 1 + verreciel.music.magnitude * 10;
       this.port.sprite_output.element.scale.x = scale;
       this.port.sprite_output.element.scale.y = scale;

--- a/verreciel_js/scripts/panels/widgets/shield.js
+++ b/verreciel_js/scripts/panels/widgets/shield.js
@@ -4,9 +4,8 @@
 class Shield extends Widget {
   constructor() {
     // assertArgs(arguments, 0);
-    super();
+    super("shield");
 
-    this.name = "shield";
     this.details = "star protection";
     this.requirement = ItemTypes.shield;
     this.isPowered = function() {

--- a/verreciel_js/scripts/panels/widgets/widget.js
+++ b/verreciel_js/scripts/panels/widgets/widget.js
@@ -2,16 +2,22 @@
 //  Copyright © 2017 XXIIVV. All rights reserved.
 
 class Widget extends Panel {
-  constructor() {
+  constructor(name) {
     // assertArgs(arguments, 0);
-    super();
+    super(name);
 
     this.isPowered = function() {
       return false;
     };
     this.requirement = null;
 
-    this.port = new ScenePortSlot(this, Alignment.center, false, "--");
+    this.port = new ScenePortSlot(
+      this,
+      "widget_" + this.name,
+      Alignment.center,
+      false,
+      "--"
+    );
     this.port.position.set(0, -0.7, Templates.radius);
     this.port.disable();
     this.port.label.updateScale(0.05);

--- a/verreciel_js/scripts/utils/tools.js
+++ b/verreciel_js/scripts/utils/tools.js
@@ -77,3 +77,17 @@ function getStackTrace() {
   Error.captureStackTrace(record, getStackTrace);
   return record.stack;
 }
+
+function loadAsset(path, callback, mimeType = null) {
+  let xhr = new XMLHttpRequest();
+  if (mimeType != null) {
+    xhr.overrideMimeType(mimeType);
+  }
+  xhr.open("GET", path, true);
+  xhr.onreadystatechange = function() {
+    if (xhr.readyState == 4 && xhr.status == "200") {
+      callback(xhr.responseText);
+    }
+  };
+  xhr.send(null);
+}

--- a/verreciel_js/scripts/utils/tools.js
+++ b/verreciel_js/scripts/utils/tools.js
@@ -51,7 +51,7 @@ function sanitizeDiffAngle(angle1, angle2, inDegrees = false) {
 
 function delay(seconds, callback) {
   // assertArgs(arguments, 2);
-  return setTimeout(callback, seconds * 1000);
+  return setTimeout(callback, seconds * 1000 / verreciel.game.gameSpeed);
 }
 
 function cancelDelay(delayID) {


### PR DESCRIPTION
Sea Peoples—

I hope your journey to Niue is going well! I wish I'd finished this in time to show you before you lost Internet access, but it was important to get it done right.

In this branch, Verreciel can now play itself from beginning to end! 😃 (For now, actually, it _only_ can play itself from the beginning.) If the player looks straight up at the very beginning, and waits patiently, they'll be moved to the back seat, and a familiar familiar will take over till the player wants to take the wheel again. Videos await you on Twitter!

Aside from bug fixes, a few features were added to the game to make this possible:
1. Most if not all in-game delays and references to game time are now modulated by verreciel.game.gameSpeed . The walkthrough actually increases game speed during times when the player and ghost are waiting for something to happen.
2. Speaking of which, almost all in-game events that require waiting broadcast reports to the new walkthrough system.
3. Speaking of which, there is a new walkthrough system that either records the reports sent to it, or checks them against the walkthrough JSON to advance the walkthrough.
4. Speaking of which, the walkthrough steps are choreographed by a shy phantasm, who dances to the radio (when it has nothing better to do) and simulates the walkthrough JSON's recorded trigger clicks.
5. Speaking of which, all triggers and ports have unique names, so they can be individually addressed, and their clicks can be individually reported.
6. I've changed the wires back to flopping around in only the Y direction– but they are now pulled down somewhat by the thruster, and flop out of sync with one another, at a frequency derived from their length.
7. The Player object now has a panoptic mode, which lets the player see almost the entire capsule from underneath.
8. The radio port now pulses with the radio audio. Completing the Radio mission is awesome already, but this kind of reinforces to the player that it was their own effort that got them their auditory reward.
9. A sound effect can now only be played so many times in a specific time window. This addresses some "over-chirping" when the player restores the game from a save.
10. An extinguished star no longer burns the player. More importantly, removing your shield when you're docked at a star now makes you flee to the last non-star you visited, so you aren't fleeing from star to star.

Give it a spin when you get a chance. Safe travels, friends! ⛵️