### PR TITLE
Fixing a ghost bug.

### DIFF
--- a/verreciel_js/scripts/core/ghost.js
+++ b/verreciel_js/scripts/core/ghost.js
@@ -175,7 +175,7 @@ class Ghost extends Empty {
   }
 
   pollForSummon() {
-    if (verreciel.game.state > 0 && verreciel.numClicks == 0) {
+    if (verreciel.game.state > 0 || verreciel.numClicks > 0) {
       return;
     }
     let playerRotation = new THREE.Vector3(


### PR DESCRIPTION
A simple mistyped condition made Ghost::pollForSummon run all the time, and trigger the ghost at invalid times.