### PR TITLE
Thick lines

### DIFF
--- a/verreciel_js/TODO.txt
+++ b/verreciel_js/TODO.txt
@@ -1,6 +1,3 @@
-Thick lines
-  some objects aren't appearing
-
 It's weird when the helmet gives old quest instructions for the current mission
   I don't mean in response to mistakes, I mean when the player's doing the right thing
 

--- a/verreciel_js/TODO.txt
+++ b/verreciel_js/TODO.txt
@@ -1,3 +1,6 @@
+Thick lines
+  some objects aren't appearing
+
 It's weird when the helmet gives old quest instructions for the current mission
   I don't mean in response to mistakes, I mean when the player's doing the right thing
 

--- a/verreciel_js/index.html
+++ b/verreciel_js/index.html
@@ -10,6 +10,8 @@
     <script type="text/javascript" src="scripts/utils/enum.js"></script>
     <script type="text/javascript" src="scripts/utils/tools.js"></script>
 
+    <script type="text/javascript" src="scripts/meshlinesegments.js"></script>
+
     <script type="text/javascript" src="scripts/animations/animator.js"></script>
     <script type="text/javascript" src="scripts/animations/animation.js"></script>
     <script type="text/javascript" src="scripts/animations/animatedproperty.js"></script>

--- a/verreciel_js/scripts/components/empty.js
+++ b/verreciel_js/scripts/components/empty.js
@@ -17,17 +17,6 @@ class Empty extends SceneNode {
     // assertArgs(arguments, 0, true);
   }
 
-  // TODO: REMOVE
-  add() {
-    if (arguments[0] == null) {
-      throw "NULL ADD";
-    }
-    if (!arguments[0] instanceof THREE.Object3D) {
-      throw "ILLEGAL ADD";
-    }
-    super.add.apply(this, arguments);
-  }
-
   empty() {
     // assertArgs(arguments, 0);
     while (this.children.length > 0) {

--- a/verreciel_js/scripts/components/scenedrawnode.js
+++ b/verreciel_js/scripts/components/scenedrawnode.js
@@ -5,6 +5,7 @@ class SceneDrawNode extends Empty {
   constructor() {
     super();
     this.__color4 = new THREE.Vector4(1, 1, 1, 1);
+    this.__materialColor = new THREE.Color();
     this.__colorRGB = new AnimatedXYZ(
       verreciel.animator,
       this,
@@ -33,9 +34,10 @@ class SceneDrawNode extends Empty {
   makeElement() {}
 
   updateMaterialColor() {
-    this.material.color.r = this.__color4.x;
-    this.material.color.g = this.__color4.y;
-    this.material.color.b = this.__color4.z;
+    this.__materialColor.r = this.__color4.x;
+    this.__materialColor.g = this.__color4.y;
+    this.__materialColor.b = this.__color4.z;
+    this.material.color = this.__materialColor;
   }
 
   updateMaterialOpacity() {

--- a/verreciel_js/scripts/components/sceneline.js
+++ b/verreciel_js/scripts/components/sceneline.js
@@ -10,12 +10,11 @@ class SceneLine extends SceneDrawNode {
   }
 
   makeElement() {
-    this.material = new THREE.LineBasicMaterial({
-      color: 0xffffff,
-      transparent: true
-    });
-    this.geometry = new THREE.Geometry();
-    this.element = new THREE.LineSegments(this.geometry, this.material);
+    this.meshLineSegments = new MeshLineSegments();
+    this.material = this.meshLineSegments.material;
+    this.material.screenAspectRatio = verreciel.width / verreciel.height;
+    this.material.lineWidth = 0.005;
+    this.element = this.meshLineSegments.element;
     super.makeElement();
   }
 
@@ -35,23 +34,12 @@ class SceneLine extends SceneDrawNode {
     if (vertices.indexOf(null) != -1) {
       throw "BAD GEOMETRY";
     }
+    this.meshLineSegments.updateGeometry(vertices);
+  }
 
-    let oldLength = this.vertices == null ? -1 : this.vertices.length;
-    this.vertices = vertices;
-    while (this.vertices.length < oldLength) {
-      this.vertices.push(SceneLine.DUD_VERT);
-    }
-
-    if (oldLength != -1 && this.vertices.length > oldLength) {
-      this.geometry.dispose();
-      this.geometry = new THREE.Geometry();
-      this.element.geometry = this.geometry;
-      // console.debug("EXPAND:", oldLength, "-->", this.vertices.length);
-    }
-
-    this.geometry.vertices = vertices;
-    this.geometry.verticesNeedUpdate = true;
-    this.geometry.computeBoundingSphere();
+  whenResize() {
+    this.material.screenAspectRatio = verreciel.width / verreciel.height;
+    super.whenResize();
   }
 }
 

--- a/verreciel_js/scripts/components/sceneline.js
+++ b/verreciel_js/scripts/components/sceneline.js
@@ -13,7 +13,7 @@ class SceneLine extends SceneDrawNode {
     this.meshLineSegments = new MeshLineSegments();
     this.material = this.meshLineSegments.material;
     this.material.screenAspectRatio = verreciel.width / verreciel.height;
-    this.material.lineWidth = 0.005;
+    this.material.lineWidth = 0.004;
     this.element = this.meshLineSegments.element;
     super.makeElement();
   }

--- a/verreciel_js/scripts/components/scenenode.js
+++ b/verreciel_js/scripts/components/scenenode.js
@@ -135,6 +135,13 @@ class SceneNode {
     }
   }
 
+  whenResize() {
+    // assertArgs(arguments, 0);
+    for (let node of this.children) {
+      node.whenResize();
+    }
+  }
+
   removeFromParentNode() {
     // assertArgs(arguments, 0);
     if (this.parent != null) {

--- a/verreciel_js/scripts/components/scenenode.js
+++ b/verreciel_js/scripts/components/scenenode.js
@@ -62,6 +62,7 @@ class SceneNode {
     this.children.push(other);
     other.parent = this;
     other.element.updateMatrixWorld(true);
+    other.whenResize();
     other.whenInherit();
     if (verreciel.phase == Phase.render) {
       other.whenRenderer();

--- a/verreciel_js/scripts/core/verreciel.js
+++ b/verreciel_js/scripts/core/verreciel.js
@@ -29,7 +29,7 @@ class Verreciel {
     this.numClicks = 0;
     this.scene = new THREE.Scene();
     this.scene.background = new THREE.Color(0, 0, 0);
-    this.renderer = new THREE.WebGLRenderer({ antialias: false });
+    this.renderer = new THREE.WebGLRenderer({ antialias: true });
     // this.renderer.sortObjects = false;
     this.renderer.setPixelRatio(window.devicePixelRatio);
     this.renderer.setSize(0, 0);
@@ -119,6 +119,7 @@ class Verreciel {
       document.body.appendChild(this.stats.dom);
     }
 
+    this.root.whenResize();
     this.lastFrameTime = Date.now();
     this.render();
   }
@@ -256,6 +257,9 @@ class Verreciel {
     this.camera.aspect = this.width / this.height;
     this.camera.updateProjectionMatrix();
     this.renderer.setSize(this.width, this.height);
+    if (this.root != null) {
+      this.root.whenResize();
+    }
   }
 }
 

--- a/verreciel_js/scripts/meshlinesegments.js
+++ b/verreciel_js/scripts/meshlinesegments.js
@@ -1,0 +1,213 @@
+class MeshLineSegments {
+  constructor(source = null) {
+    this.geometry = new THREE.BufferGeometry();
+    this.geometry.setDrawRange(0, Infinity);
+    this.material = new MeshLineSegmentsMaterial();
+    this.material.lineWidth = 0.01;
+    this.element = new THREE.Mesh(this.geometry, this.material);
+    if (source != null) {
+      this.updateGeometry(source);
+    }
+  }
+
+  remakeGeometry(source) {
+    // Counts
+    this.numQuadSegments = source.length / 2;
+    this.numTriangles = this.numQuadSegments * 2;
+    this.numIndices = this.numTriangles * 3;
+    this.numVertices = this.numQuadSegments * 4;
+
+    // Indices
+    this.indices = new Uint32Array(this.numIndices);
+    for (let i = 0; i < this.numQuadSegments; i++) {
+      this.indices[i * 6 + 0] = (i * 4 + 0) % this.numVertices;
+      this.indices[i * 6 + 1] = (i * 4 + 1) % this.numVertices;
+      this.indices[i * 6 + 2] = (i * 4 + 2) % this.numVertices;
+      this.indices[i * 6 + 3] = (i * 4 + 1) % this.numVertices;
+      this.indices[i * 6 + 4] = (i * 4 + 2) % this.numVertices;
+      this.indices[i * 6 + 5] = (i * 4 + 3) % this.numVertices;
+    }
+    this.geometry.setIndex(new THREE.BufferAttribute(this.indices, 1));
+
+    // Start and End Positions
+    this.startPositions = new Float32Array(this.numVertices * 3);
+    this.startPositionsAttribute = new THREE.BufferAttribute(
+      this.startPositions,
+      3
+    );
+    this.geometry.addAttribute("startPosition", this.startPositionsAttribute);
+
+    this.endPositions = new Float32Array(this.numVertices * 3);
+    this.endPositionsAttribute = new THREE.BufferAttribute(
+      this.endPositions,
+      3
+    );
+    this.geometry.addAttribute("endPosition", this.endPositionsAttribute);
+
+    this.positions = new Float32Array(source.length * 3);
+    this.positionsAttribute = new THREE.BufferAttribute(this.positions, 3);
+    this.geometry.addAttribute("position", this.positionsAttribute); // for boundary computing
+
+    // Side and Edge offsets
+    this.sides = new Float32Array(this.numVertices);
+    for (let i = 0; i < this.numVertices; i++) {
+      this.sides[i] = i % 2 * 2 - 1;
+    }
+    this.sidesAttribute = new THREE.BufferAttribute(this.sides, 1);
+    this.geometry.addAttribute("side", this.sidesAttribute);
+
+    this.edges = new Float32Array(this.numVertices);
+    for (let i = 0; i < this.numVertices; i++) {
+      this.edges[i] = Math.floor(i / 2) % 2 * 2 - 1;
+    }
+    this.edgesAttribute = new THREE.BufferAttribute(this.edges, 1);
+    this.geometry.addAttribute("edge", this.edgesAttribute);
+  }
+
+  copyPosition(arr, index, pos) {
+    arr[index * 3 + 0] = pos.x;
+    arr[index * 3 + 1] = pos.y;
+    arr[index * 3 + 2] = pos.z;
+  }
+
+  updateGeometry(source) {
+    if (source.length / 2 != this.numQuadSegments) {
+      this.remakeGeometry(source);
+    }
+
+    for (let i = 0; i < this.numQuadSegments; i++) {
+      let start = source[i * 2 + 0];
+      this.copyPosition(this.startPositions, i * 4 + 0, start);
+      this.copyPosition(this.startPositions, i * 4 + 1, start);
+      this.copyPosition(this.startPositions, i * 4 + 2, start);
+      this.copyPosition(this.startPositions, i * 4 + 3, start);
+
+      let end = source[i * 2 + 1];
+      this.copyPosition(this.endPositions, i * 4 + 0, end);
+      this.copyPosition(this.endPositions, i * 4 + 1, end);
+      this.copyPosition(this.endPositions, i * 4 + 2, end);
+      this.copyPosition(this.endPositions, i * 4 + 3, end);
+
+      this.copyPosition(this.positions, i * 2 + 0, start);
+      this.copyPosition(this.positions, i * 2 + 1, end);
+    }
+
+    this.startPositionsAttribute.setArray(this.startPositions);
+    this.startPositionsAttribute.needsUpdate = true;
+
+    this.endPositionsAttribute.setArray(this.endPositions);
+    this.endPositionsAttribute.needsUpdate = true;
+
+    this.positionsAttribute.setArray(this.positions);
+
+    this.geometry.computeBoundingSphere();
+  }
+}
+
+class MeshLineSegmentsMaterial extends THREE.ShaderMaterial {
+  constructor(params) {
+    let innerParams = { side: THREE.DoubleSide, transparent: true };
+    if (params != null) {
+      for (let prop in params) {
+        innerParams[prop] = params[prop];
+      }
+    }
+    super(innerParams);
+
+    this.uniforms.screenAspectRatio = { value: 1 };
+    this.uniforms.lineWidth = { value: 1 };
+    this.uniforms.diffuse = { value: new THREE.Vector3(1, 1, 1) };
+    this.uniforms.opacity = { value: 1.0 };
+
+    this.vertexShader = `
+            attribute vec3 startPosition;
+            attribute vec3 endPosition;
+            attribute float side;
+            attribute float edge;
+            uniform float screenAspectRatio;
+            uniform float lineWidth;
+
+            void main() {
+                
+                mat4 screenFromModelView = projectionMatrix * modelViewMatrix;
+
+                vec4 startScreenPosition = screenFromModelView * vec4( startPosition, 1.0 );
+                vec4 endScreenPosition   = screenFromModelView * vec4( endPosition,   1.0 );
+
+                vec4 currScreenPosition = edge == 1.0 ? startScreenPosition : endScreenPosition;
+
+                vec2 startXY = startScreenPosition.xy / startScreenPosition.w * vec2(screenAspectRatio, 1.0);
+                vec2 endXY = endScreenPosition.xy / endScreenPosition.w * vec2(screenAspectRatio, 1.0);
+
+                vec2 dir = normalize(endXY - startXY);
+                vec2 normal = vec2( -dir.y / screenAspectRatio,  dir.x ) * lineWidth / 2.0;
+                currScreenPosition.xy += side * normal * currScreenPosition.w;
+
+                if (startXY != endXY) {
+                  vec2 bloat = vec2( dir.x / screenAspectRatio,  dir.y ) * lineWidth / 2.0;
+                  currScreenPosition.xy += -edge * bloat * currScreenPosition.w;
+                }
+                
+                gl_Position = currScreenPosition;
+            }
+        `;
+
+    this.fragmentShader = `
+            uniform vec3 diffuse;
+            uniform float opacity;
+
+            void main() {
+                vec4 diffuseColor = vec4( diffuse, opacity );
+                gl_FragColor = diffuseColor;
+            }
+        `;
+  }
+
+  get screenAspectRatio() {
+    return this.uniforms.screenAspectRatio.value;
+  }
+
+  set screenAspectRatio(newValue) {
+    this.uniforms.screenAspectRatio.value = newValue;
+  }
+
+  get lineWidth() {
+    return this.uniforms.lineWidth.value;
+  }
+
+  set lineWidth(newValue) {
+    this.uniforms.lineWidth.value = newValue;
+  }
+
+  get diffuse() {
+    return this.uniforms.diffuse.value;
+  }
+
+  set diffuse(newValue) {
+    this.uniforms.diffuse.value = newValue;
+  }
+
+  get opacity() {
+    return this.uniforms.opacity.value;
+  }
+
+  set opacity(newValue) {
+    if (this.uniforms != null) this.uniforms.opacity.value = newValue;
+  }
+
+  get screenAspectRatio() {
+    return this.uniforms.screenAspectRatio.value;
+  }
+
+  set screenAspectRatio(newValue) {
+    this.uniforms.screenAspectRatio.value = newValue;
+  }
+
+  get color() {
+    return new THREE.Color().fromArray(this.uniforms.diffuse.value.toArray());
+  }
+
+  set color(newColor) {
+    this.uniforms.diffuse.value.fromArray(newColor.toArray());
+  }
+}

--- a/verreciel_js/scripts/meshlinesegments.js
+++ b/verreciel_js/scripts/meshlinesegments.js
@@ -1,3 +1,6 @@
+//  Created by Devine Lu Linvega.
+//  Copyright © 2017 XXIIVV. All rights reserved.
+
 class MeshLineSegments {
   constructor(source = null) {
     this.geometry = new THREE.BufferGeometry();


### PR DESCRIPTION
Sea Peoples—

First of all, the Niue travelogue video blew my mind.

Secondly, I made a change to the Verreciel line rendering in this PR. Previously, lines were all drawn with ThreeJS's wrapper of the OpenGL line drawing operation. This pull request replaces SceneLine's dependency on that wrapper with an instance of the new MeshLineSegments, which draws a quad instead of a line, and has a lineWidth property. It seems to perform pretty well. It draws quite a bit from [Drawing Lines is Hard](https://mattdesl.svbtle.com/drawing-lines-is-hard).

The main downside to this pull request is that OpenGL's line drawing method has a certain pixel-y charm that doesn't survive the switch. Turning off anti-aliasing won't help– there's always going to be a difference between two super-thin triangles and a bona fide [Bresenham](https://en.wikipedia.org/wiki/Bresenham%27s_line_algorithm).

The major upside is, Verreciel is now resolution-independent. Lines on a 4K screen should be four times as big as lines on a 1080p screen. And on both screens, they'll be more than a pixel wide, the major limitation of OpenGL line drawing.

Another advantage is, Verreciel can now adjust the thickness of any line for creative purposes. The only restriction is that there are no miters between line segments; after all, they're just segments, with no conceptual connection, even though they're in the same geometry buffer.

Well, that got technical! I want to point out that deciding to draw everything as lines is one of the reasons Verreciel ever made it to Chrome. GL.LINES is unorthodox in 2017, but it paid off.

Smooth sailing, friends! Enjoy the trip to Tonga!